### PR TITLE
Filtering and caching

### DIFF
--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -79,8 +79,9 @@
 			} else {
 				rows.hide();
 		
+				var regex = new RegExp('\\b' + term, 'i');
 				this._trigger( "filter", e, $.map(cache, function(v,i){
-					if ( v.indexOf(term) !== -1 ){
+					if ( v.search(regex) != -1 ){
 						rows.eq(i).show();
 						return inputs.get(i);
 					}
@@ -96,6 +97,9 @@
 			
 			this.cache = optiontags.map(function(){
 				var self = $(this), nodes = self;
+
+				// see _create() in jquery.multiselect.js around line 96
+				if (!self.val().length) return null;
 				
 				// account for optgroups
 				if( isOptgroup ){


### PR DESCRIPTION
Turns out if you have an option with a blank value it becomes part of the cache but not part of the `this.rows`.

Also, when working with your files all sorts of trouble happened. Probably because of weird line endings. Would you consider changing to \n line endings and replace all tabs with spaces? 
