### PR TITLE
Bug: Enter key not selecting origin in Single mode

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -312,7 +312,7 @@ $.widget("ech.multiselect", {
 						break;
 					case 13: // enter
 						e.preventDefault();
-						$(this).find('input').trigger('click');
+						$(this).find('input')[0].click();
 						break;
 				}
 			})


### PR DESCRIPTION
you can reproduce it on this jsfiddle (Firefox):
http://jsfiddle.net/xaDvh/2/

try clicking on say 4, check it is selected with the button I added.
next use enter to select say 5. Check if it's selected.
