### PR TITLE
I think you should look for the selected attribute instead of .selected

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -155,7 +155,7 @@ $.widget("ech.multiselect", {
 			html.push('<input id="'+inputID+'" name="multiselect_'+id+'" type="'+(o.multiple ? "checkbox" : "radio")+'" value="'+value+'" title="'+title+'"');
 
 			// pre-selected?
-			if( this.selected ){
+			if( this.attributes['selected'] ){
 				html.push(' checked="checked"');
 				html.push(' aria-selected="true"');
 			}


### PR DESCRIPTION
I think you should look for the selected attribute instead of using the .selected method. The first element is always returned for .selected (at least in webkit).  Presence of the selected attribute indicates that the author intended an item to be preselected.
