### PR TITLE
another try...

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -154,8 +154,8 @@ $.widget("ech.multiselect", {
 			html.push('<label for="'+inputID+'" class="'+labelClasses.join(' ')+ '">');
 			html.push('<input id="'+inputID+'" name="multiselect_'+id+'" type="'+(o.multiple ? "checkbox" : "radio")+'" value="'+value+'" title="'+title+'"');
 
-			// pre-selected?
-			if( this.selected ){
+			// pre selected or refreshing a multi-selection list
+			if( (this.selected && o.multiple) || attributes['selected'] ){
 				html.push(' checked="checked"');
 				html.push(' aria-selected="true"');
 			}


### PR DESCRIPTION
What do you think of this? works for my case and I think it's universally reasonable. 
- if a single select list has an explicit selected attrib it's respected (i guess just the last one)
- multi selects refresh as before
- single selects show a prompt
  
  I can't see a way to detect that noneSelectedText is set and multiple=false. I think it still makes sense not to pick the first item even when noneSeletedText is not explicitly set. Do you think an option like o.selectFirstItem = true is warranted, or maybe something like defaultSelectedItem = N ? 
  I don't see much utility to those. 

Is there some other way to make the single select with no default use case work?  
