### PR TITLE
Added reselect method to update selected checkboxes from html-select without rebuilding widget

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -196,6 +196,29 @@ $.widget("ech.multiselect", {
 		}
 	},
 	
+	
+	// reselects checkboxes in widget. Does not rebuild widget - better performance on large amout of options
+	reselect: function(){
+ 		var self = this;
+ 			
+		// Reselect multiselect
+		this.element.find('option').each(function( i ){
+ 			var isSelected = this.selected;
+ 			// selected?
+			if( isSelected ){
+				$(self.labels[i]).children('input').attr('checked', 'checked').attr('aria-selected', true);
+			}
+			else {
+				$(self.labels[i]).children('input').removeAttr('checked').removeAttr('aria-selected');
+			}
+		});
+	
+		this.update();
+		
+		this._trigger('reselect');
+	},
+	
+	
 	// updates the button text.  call refresh() to rebuild
 	update: function(){
 		var o = this.options,


### PR DESCRIPTION
Just wrote a litte additional function for your widget. If you need to reselect/update the widget without it beeing rebuild ("refresh") you can use ("reselect"). So its better if you got a lot of entries, need performance and you change something directly on the selectbox. Fairly simple, but performance optimized (especially on IE8)
