### PR TITLE
Optgroups within options

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -138,7 +138,7 @@ $.widget("ech.multiselect", {
 			// is this an optgroup?
 			if( parent.tagName.toLowerCase() === 'optgroup' ){
 				optLabel = parent.getAttribute('label');
-				
+
 				// has this optgroup been added already?
 				if( $.inArray(optLabel, optgroups) === -1 ){
 					html.push('<li class="ui-multiselect-optgroup-label"><a href="#">' + optLabel + '</a></li>');
@@ -176,6 +176,14 @@ $.widget("ech.multiselect", {
 
 			// add the title and close everything off
 			html.push(' /><span>' + title + '</span></label></li>');
+			
+			// End optgroup
+			if( parent.tagName.toLowerCase() === 'optgroup' ){
+				var $next_parent = $this.next('option').parent();
+				if ( !$next_parent.is('optgroup') ) {
+					html.push('<li class="ui-multiselect-optgroup-last"></li>');
+				}
+			}
 		});
 		
 		// insert into the DOM
@@ -290,7 +298,7 @@ $.widget("ech.multiselect", {
 				e.preventDefault();
 				
 				var $this = $(this),
-					$inputs = $this.parent().nextUntil('li.ui-multiselect-optgroup-label').find('input:visible:not(:disabled)'),
+					$inputs = $this.parent().nextUntil('li.ui-multiselect-optgroup-label, li.ui-multiselect-optgroup-last').find('input:visible:not(:disabled)'),
 				    nodes = $inputs.get(),
 				    label = $this.parent().text();
 				


### PR DESCRIPTION
When using a few optgroups within other options the optgroup headings did not behave correctly. It would select all options beyond the end of the optgroup.

I encountered this when doing a state/country selector - not all countries have states.

To get around this issue I check for the last 'option' in the optgroup and add a list element to mark the end.