### PR TITLE
noneSelectedText, button a tag

### DIFF
--- a/jquery.multiselect.css
+++ b/jquery.multiselect.css
@@ -1,5 +1,6 @@
 .ui-multiselect { padding:2px 0 2px 4px; text-align:left }
 .ui-multiselect span.ui-icon { float:right }
+.ui-multiselect span.ui-button-text { padding: 0 0.1em; }
 .ui-multiselect-single .ui-multiselect-checkboxes input { position:absolute !important; top: auto !important; left:-9999px; }
 .ui-multiselect-single .ui-multiselect-checkboxes label { padding:5px !important }
 

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -206,7 +206,11 @@ $.widget("ech.multiselect", {
 			value;
 		
 		if( numChecked === 0 ){
-			value = o.noneSelectedText;
+			if($.isFunction(o.noneSelectedText)){
+          		value = o.noneSelectedText.call(this);
+			} else {
+				value = o.noneSelectedText;
+			}
 		} else {
 			if($.isFunction( o.selectedText )){
 				value = o.selectedText.call(this, numChecked, $inputs.length, $checked.get());

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -47,9 +47,9 @@ $.widget("ech.multiselect", {
 		
 		this.speed = $.fx.speeds._default; // default speed for effects
 		this._isOpen = false; // assume no
-	
+		
 		var 
-			button = (this.button = $('<button type="button"><span class="ui-icon ui-icon-triangle-2-n-s"></span></button>'))
+			button = (this.button = $('<a href="#" class="ui-control"><span class="ui-icon ui-icon-triangle-2-n-s"></span></a>').button())
 				.addClass('ui-multiselect ui-widget ui-state-default ui-corner-all')
 				.addClass( o.classes )
 				.attr({ 'title':el.attr('title'), 'aria-haspopup':true, 'tabIndex':el.attr('tabIndex') })

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -207,7 +207,7 @@ $.widget("ech.multiselect", {
 		
 		if( numChecked === 0 ){
 			if($.isFunction(o.noneSelectedText)){
-          		value = o.noneSelectedText.call(this);
+				value = o.noneSelectedText.call(this);
 			} else {
 				value = o.noneSelectedText;
 			}

--- a/tests/unit/events.js
+++ b/tests/unit/events.js
@@ -242,18 +242,20 @@
 	
 	
 	test("multiselectbeforeoptgrouptoggle", function(){
-		expect(11);
+		expect(10);
 		
 		// inject widget
 		el = $('<select multiple><optgroup label="Set One"><option value="1">Option 1</option><option value="2">Option 2</option></optgroup></select>').appendTo(body);
 
-		el.multiselect({
+		el.bind("change", function(){
+			ok(true, "the select's change event fires");
+		})
+		.multiselect({
 			beforeoptgrouptoggle: function(e,ui){
 				equals(this, el[0], "option: context of callback");
 				equals(e.type, 'multiselectbeforeoptgrouptoggle', 'option: event type in callback');
 				equals(ui.label, "Set One", 'option: ui.label equals');
 				equals(ui.inputs.length, 2, 'option: number of inputs in the ui.inputs key');
-				ok(true, "option: the select's change event fires");
 			}
 		})
 		.bind("multiselectbeforeoptgrouptoggle", function(e,ui){
@@ -261,7 +263,6 @@
 			equals(this, el[0], 'event: context of event');
 			equals(ui.label, "Set One", 'event: ui.label equals');
 			equals(ui.inputs.length, 2, 'event: number of inputs in the ui.inputs key');
-			ok(true, "event: the select's change event fires");
 		})
 		.multiselect("open");
 		
@@ -270,7 +271,10 @@
 		el.multiselect("destroy").remove();
 		
 		// test return false preventing checkboxes from activating
-		el.multiselect({
+		el.bind("change", function(){
+			// this should not fire.
+			ok( true );
+		}).multiselect({
 			beforeoptgrouptoggle: function(){
 				return false;
 			},


### PR DESCRIPTION
- Allow to define noneSelectedText  as callback function.
- Change button tag to 'a' element, this allow to use tool tips and other stuff inside the button element
  (inside button element events are blocked)
