### PR TITLE
consider <title> attribute in original option tags

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -128,7 +128,7 @@ $.widget("ech.multiselect", {
 			var $this = $(this), 
 				parent = this.parentNode,
 				title = this.innerHTML,
-				description = this.title,
+				description = $this.attr("title") || this.title,
 				value = this.value,
 				inputID = this.id || 'ui-multiselect-' + id + '-option-' + i,
 				isDisabled = this.disabled,


### PR DESCRIPTION
if the option's already have a title attribute, use it as the title on generated labels, if not, leave the original behavior.
