### PR TITLE
added support for lazy load of multiselect data from ajax/callback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/jquery.multiselect.css
+++ b/jquery.multiselect.css
@@ -21,3 +21,6 @@
 
 /* remove label borders in IE6 because IE6 does not support transparency */
 * html .ui-multiselect-checkboxes label { border:none }
+
+/* loading spinner */
+.ui-multiselect-loading { background: white url('images/ui-anim_basic_16x16.gif') right center no-repeat; }

--- a/lib/jquery.mockjax.js
+++ b/lib/jquery.mockjax.js
@@ -1,0 +1,409 @@
+/*!
+ * MockJax - jQuery Plugin to Mock Ajax requests
+ *
+ * Version:  1.5.0pre
+ * Released:
+ * Home:   http://github.com/appendto/jquery-mockjax
+ * Author:   Jonathan Sharp (http://jdsharp.com)
+ * License:  MIT,GPL
+ *
+ * Copyright (c) 2011 appendTo LLC.
+ * Dual licensed under the MIT or GPL licenses.
+ * http://appendto.com/open-source-licenses
+ */
+(function($) {
+	var _ajax = $.ajax,
+		mockHandlers = [];
+
+	function parseXML(xml) {
+		if ( window['DOMParser'] == undefined && window.ActiveXObject ) {
+			DOMParser = function() { };
+			DOMParser.prototype.parseFromString = function( xmlString ) {
+				var doc = new ActiveXObject('Microsoft.XMLDOM');
+				doc.async = 'false';
+				doc.loadXML( xmlString );
+				return doc;
+			};
+		}
+
+		try {
+			var xmlDoc 	= ( new DOMParser() ).parseFromString( xml, 'text/xml' );
+			if ( $.isXMLDoc( xmlDoc ) ) {
+				var err = $('parsererror', xmlDoc);
+				if ( err.length == 1 ) {
+					throw('Error: ' + $(xmlDoc).text() );
+				}
+			} else {
+				throw('Unable to parse XML');
+			}
+		} catch( e ) {
+			var msg = ( e.name == undefined ? e : e.name + ': ' + e.message );
+			$(document).trigger('xmlParseError', [ msg ]);
+			return undefined;
+		}
+		return xmlDoc;
+	}
+
+	$.extend({
+		ajax: function(url, origSettings) {
+			// If url is an object, simulate pre-1.5 signature
+			if ( typeof url === "object" ) {
+				origSettings = url;
+				url = undefined;
+			} else {
+				// work around to support 1.5 signature
+				origSettings.url = url;
+			}
+			var s = jQuery.extend(true, {}, jQuery.ajaxSettings, origSettings),
+				mock = false;
+			// Iterate over our mock handlers (in registration order) until we find
+			// one that is willing to intercept the request
+			$.each(mockHandlers, function(k, v) {
+				if ( !mockHandlers[k] ) {
+					return;
+				}
+				var m = null;
+				// If the mock was registered with a function, let the function decide if we
+				// want to mock this request
+				if ( $.isFunction(mockHandlers[k]) ) {
+					m = mockHandlers[k](s);
+				} else {
+					m = mockHandlers[k];
+					// Inspect the URL of the request and check if the mock handler's url
+					// matches the url for this ajax request
+					if ( $.isFunction(m.url.test) ) {
+						// The user provided a regex for the url, test it
+						if ( !m.url.test( s.url ) ) {
+							m = null;
+						}
+					} else {
+						// Look for a simple wildcard '*' or a direct URL match
+						var star = m.url.indexOf('*');
+						if (m.url !== s.url && star === -1 || !new RegExp(m.url.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&").replace('*', '.+')).test(s.url)) {
+							m = null;
+						}
+					}
+					if ( m ) {
+						// Inspect the data submitted in the request (either POST body or GET query string)
+						if ( m.data && s.data ) {
+							var identical = false;
+							// Deep inspect the identity of the objects
+							(function ident(mock, live) {
+								// Test for situations where the data is a querystring (not an object)
+								if (typeof live === 'string') {
+									// Querystring may be a regex
+									identical = $.isFunction( mock.test ) ? mock.test(live) : mock == live;
+									return identical;
+								}
+								$.each(mock, function(k, v) {
+									if ( live[k] === undefined ) {
+										identical = false;
+										return false;
+									} else {
+										identical = true;
+										if ( typeof live[k] == 'object' ) {
+											return ident(mock[k], live[k]);
+										} else {
+											if ( $.isFunction( mock[k].test ) ) {
+												identical = mock[k].test(live[k]);
+											} else {
+												identical = ( mock[k] == live[k] );
+											}
+											return identical;
+										}
+									}
+								});
+							})(m.data, s.data);
+							// They're not identical, do not mock this request
+							if ( identical == false ) {
+								m = null;
+							}
+						}
+						// Inspect the request type
+						if ( m && m.type && m.type.toLowerCase() != s.type.toLowerCase() ) {
+							// The request type doesn't match (GET vs. POST)
+							m = null;
+						}
+					}
+				}
+				if ( m ) {
+					mock = true;
+
+					// Handle console logging
+					var c = $.extend({}, $.mockjaxSettings, m);
+					if ( c.log && $.isFunction(c.log) ) {
+						c.log('MOCK ' + s.type.toUpperCase() + ': ' + s.url, $.extend({}, s));
+					}
+
+					var jsre = /=\?(&|$)/, jsc = (new Date()).getTime();
+
+					// Handle JSONP Parameter Callbacks, we need to replicate some of the jQuery core here
+					// because there isn't an easy hook for the cross domain script tag of jsonp
+					if ( s.dataType === "jsonp" ) {
+						if ( s.type.toUpperCase() === "GET" ) {
+							if ( !jsre.test( s.url ) ) {
+								s.url += (rquery.test( s.url ) ? "&" : "?") + (s.jsonp || "callback") + "=?";
+							}
+						} else if ( !s.data || !jsre.test(s.data) ) {
+							s.data = (s.data ? s.data + "&" : "") + (s.jsonp || "callback") + "=?";
+						}
+						s.dataType = "json";
+					}
+
+					// Build temporary JSONP function
+					if ( s.dataType === "json" && (s.data && jsre.test(s.data) || jsre.test(s.url)) ) {
+						jsonp = s.jsonpCallback || ("jsonp" + jsc++);
+
+						// Replace the =? sequence both in the query string and the data
+						if ( s.data ) {
+							s.data = (s.data + "").replace(jsre, "=" + jsonp + "$1");
+						}
+
+						s.url = s.url.replace(jsre, "=" + jsonp + "$1");
+
+						// We need to make sure
+						// that a JSONP style response is executed properly
+						s.dataType = "script";
+
+						// Handle JSONP-style loading
+						window[ jsonp ] = window[ jsonp ] || function( tmp ) {
+							data = tmp;
+							success();
+							complete();
+							// Garbage collect
+							window[ jsonp ] = undefined;
+
+							try {
+								delete window[ jsonp ];
+							} catch(e) {}
+
+							if ( head ) {
+								head.removeChild( script );
+							}
+						};
+					}
+
+					var rurl = /^(\w+:)?\/\/([^\/?#]+)/,
+						parts = rurl.exec( s.url ),
+						remote = parts && (parts[1] && parts[1] !== location.protocol || parts[2] !== location.host);
+
+					// Test if we are going to create a script tag (if so, intercept & mock)
+					if ( s.dataType === "script" && s.type.toUpperCase() === "GET" && remote ) {
+						// Synthesize the mock request for adding a script tag
+						var callbackContext = origSettings && origSettings.context || s;
+
+						function success() {
+							// If a local callback was specified, fire it and pass it the data
+							if ( s.success ) {
+								s.success.call( callbackContext, ( m.response ? m.response.toString() : m.responseText || ''), status, {} );
+							}
+
+							// Fire the global callback
+							if ( s.global ) {
+								trigger( "ajaxSuccess", [{}, s] );
+							}
+						}
+
+						function complete() {
+							// Process result
+							if ( s.complete ) {
+								s.complete.call( callbackContext, {} , status );
+							}
+
+							// The request was completed
+							if ( s.global ) {
+								trigger( "ajaxComplete", [{}, s] );
+							}
+
+							// Handle the global AJAX counter
+							if ( s.global && ! --jQuery.active ) {
+								jQuery.event.trigger( "ajaxStop" );
+							}
+						}
+
+						function trigger(type, args) {
+							(s.context ? jQuery(s.context) : jQuery.event).trigger(type, args);
+						}
+
+						if ( m.response && $.isFunction(m.response) ) {
+							m.response(origSettings);
+						} else {
+							$.globalEval(m.responseText);
+						}
+						success();
+						complete();
+						return false;
+					}
+
+					m.data = s.data;
+				  m.cache = s.cache;
+				  m.timeout = s.timeout;
+				  m.global = s.global;
+
+					mock = _ajax.call($, $.extend(true, {}, origSettings, {
+						// Mock the XHR object
+						xhr: function() {
+							// Extend with our default mockjax settings
+							m = $.extend({}, $.mockjaxSettings, m);
+
+							if (typeof m.headers === 'undefined') {
+								m.headers = {};
+							}
+							if ( m.contentType ) {
+								m.headers['content-type'] = m.contentType;
+							}
+
+							// Return our mock xhr object
+							return {
+								status: m.status,
+								readyState: 1,
+								open: function() { },
+								send: function() {
+
+								  mockHandlers[k].fired = true;
+
+									// This is a substitute for < 1.4 which lacks $.proxy
+									var process = (function(that) {
+										return function() {
+											return (function() {
+												// The request has returned
+												this.status 		= m.status;
+												this.readyState 	= 4;
+
+												// We have an executable function, call it to give
+												// the mock handler a chance to update it's data
+												if ( $.isFunction(m.response) ) {
+													m.response(origSettings);
+												}
+												// Copy over our mock to our xhr object before passing control back to
+												// jQuery's onreadystatechange callback
+												if ( s.dataType == 'json' && ( typeof m.responseText == 'object' ) ) {
+													this.responseText = JSON.stringify(m.responseText);
+												} else if ( s.dataType == 'xml' ) {
+													if ( typeof m.responseXML == 'string' ) {
+														this.responseXML = parseXML(m.responseXML);
+													} else {
+														this.responseXML = m.responseXML;
+													}
+												} else {
+													this.responseText = m.responseText;
+												}
+												if( typeof m.status == 'number' || typeof m.status == 'string' ) {
+												  this.status = m.status;
+												}
+												// jQuery < 1.4 doesn't have onreadystate change for xhr
+												if ( $.isFunction(this.onreadystatechange) ) {
+													this.onreadystatechange( m.isTimeout ? 'timeout' : undefined );
+												}
+											}).apply(that);
+										};
+									})(this);
+
+									if ( m.proxy ) {
+										// We're proxying this request and loading in an external file instead
+										_ajax({
+											global: false,
+											url: m.proxy,
+											type: m.proxyType,
+											data: m.data,
+											dataType: s.dataType,
+											complete: function(xhr, txt) {
+												m.responseXML = xhr.responseXML;
+												m.responseText = xhr.responseText;
+												m.status = xhr.status;
+												this.responseTimer = setTimeout(process, m.responseTime || 0);
+											}
+										});
+									} else {
+										// type == 'POST' || 'GET' || 'DELETE'
+										if ( s.async === false ) {
+											// TODO: Blocking delay
+											process();
+										} else {
+											this.responseTimer = setTimeout(process, m.responseTime || 50);
+										}
+									}
+								},
+								abort: function() {
+									clearTimeout(this.responseTimer);
+								},
+								setRequestHeader: function(header, value) {
+									m.headers[header] = value;
+								},
+								getResponseHeader: function(header) {
+									// 'Last-modified', 'Etag', 'content-type' are all checked by jQuery
+									if ( m.headers && m.headers[header] ) {
+										// Return arbitrary headers
+										return m.headers[header];
+									} else if ( header.toLowerCase() == 'last-modified' ) {
+										return m.lastModified || (new Date()).toString();
+									} else if ( header.toLowerCase() == 'etag' ) {
+										return m.etag || '';
+									} else if ( header.toLowerCase() == 'content-type' ) {
+										return m.contentType || 'text/plain';
+									}
+								},
+								getAllResponseHeaders: function() {
+									var headers = '';
+									$.each(m.headers, function(k, v) {
+										headers += k + ': ' + v + "\n";
+									});
+									return headers;
+								}
+							};
+						}
+					}));
+					return false;
+				}
+			});
+			// We don't have a mock request, trigger a normal request
+			if ( !mock ) {
+				return _ajax.apply($, arguments);
+			} else {
+				return mock;
+			}
+		}
+	});
+
+	$.mockjaxSettings = {
+		//url:        null,
+		//type:       'GET',
+		log:          function(msg) {
+						window['console'] && window.console.log && window.console.log(msg);
+					  },
+		status:       200,
+		responseTime: 500,
+		isTimeout:    false,
+		contentType:  'text/plain',
+		response:     '',
+		responseText: '',
+		responseXML:  '',
+		proxy:        '',
+		proxyType:    'GET',
+
+		lastModified: null,
+		etag:         '',
+		headers: {
+			etag: 'IJF@H#@923uf8023hFO@I#H#',
+			'content-type' : 'text/plain'
+		}
+	};
+
+	$.mockjax = function(settings) {
+		var i = mockHandlers.length;
+		mockHandlers[i] = settings;
+		return i;
+	};
+	$.mockjaxClear = function(i) {
+		if ( arguments.length == 1 ) {
+			mockHandlers[i] = null;
+		} else {
+			mockHandlers = [];
+		}
+	};
+	$.mockjax.handler = function(i) {
+	  if ( arguments.length == 1 ) {
+			return mockHandlers[i];
+		}
+	};
+})(jQuery);

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -39,7 +39,10 @@ $.widget("ech.multiselect", {
 		hide: '',
 		autoOpen: false,
 		multiple: true,
-		position: {}
+		position: {},
+		source: null,
+		valueAttribute : 'id',
+		descAttribute: 'value'
 	},
 
 	_create: function(){
@@ -48,6 +51,7 @@ $.widget("ech.multiselect", {
 		
 		this.speed = $.fx.speeds._default; // default speed for effects
 		this._isOpen = false; // assume no
+		this._isLoaded = !o.source;
 	
 		var 
 			button = (this.button = $('<button type="button"><span class="ui-icon ui-icon-triangle-2-n-s"></span></button>'))
@@ -91,7 +95,10 @@ $.widget("ech.multiselect", {
 		this._bindEvents();
 		
 		// build menu
-		this.refresh( true );
+
+		if (this._isLoaded){
+			this.refresh( true );
+		}
 		
 		// some addl. logic for single selects
 		if( !o.multiple ){
@@ -398,6 +405,39 @@ $.widget("ech.multiselect", {
 		});
 	},
 
+	_loadData: function(options) {
+		var s = options.source;
+		if (typeof s == "string") {
+			$.ajax({
+				url: s,
+				data: options.data,
+				error: this._onLoadError,
+				success: this._onLoadSuccess,
+				context: this
+			});
+		}
+		else if (typeof s == "function") {
+			this._onLoadSuccess(s.call(this));
+		}
+	},
+
+	_onLoadError: function(data, status, xhr) {
+		throw "Attempt to load resulted in status: " + status;
+	},
+
+	_onLoadSuccess: function(data, status, xhr) {
+		var self = this;
+		$(data).each(function(index, item) {
+        	$("<option>")
+          		.html( item[self.options.descAttribute])
+          		.attr( "value", item[self.options.valueAttribute])
+          		.appendTo( self.element );
+		});
+		this.refresh(true);
+		this._isLoaded = true;
+		this._drawMenu();
+	},
+
 	// set button width
 	_setButtonWidth: function(){
 		var width = this.element.outerWidth(),
@@ -512,21 +552,13 @@ $.widget("ech.multiselect", {
 		this.element
 			.attr({ 'disabled':flag, 'aria-disabled':flag });
 	},
-	
-	// open the menu
-	open: function( e ){
-		var self = this,
-			button = this.button,
+
+	_drawMenu: function() {
+		var button = this.button,
 			menu = this.menu,
 			speed = this.speed,
-			o = this.options;
-		
-		// bail if the multiselectopen event returns false, this widget is disabled, or is already open 
-		if( this._trigger('beforeopen') === false || button.hasClass('ui-state-disabled') || this._isOpen ){
-			return;
-		}
-		
-		var $container = menu.find('ul').last(),
+			o = this.options,
+			$container = menu.find('ul').last(),
 			effect = o.show,
 			pos = button.offset();
 		
@@ -564,7 +596,22 @@ $.widget("ech.multiselect", {
 		
 		button.addClass('ui-state-active');
 		this._isOpen = true;
-		this._trigger('open');
+		this._trigger('open');		
+	},
+	
+	// open the menu
+	open: function( e ){
+		// bail if the multiselectopen event returns false, this widget is disabled, or is already open 
+		if( this._trigger('beforeopen') === false || this.button.hasClass('ui-state-disabled') || this._isOpen ){
+			return;
+		}
+
+		if (!this._isLoaded && this.options.source) {
+			this._loadData(this.options);
+		}
+		else {
+			this._drawMenu();
+		}
 	},
 	
 	// close the menu

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -406,14 +406,23 @@ $.widget("ech.multiselect", {
 	},
 
 	_loadData: function(options) {
-		var s = options.source;
+		var s = options.source,
+			self = this;
 		if (typeof s == "string") {
 			$.ajax({
 				url: s,
 				data: options.data,
 				error: this._onLoadError,
 				success: this._onLoadSuccess,
-				context: this
+				context: this,
+				beforeSend: function() { 
+					self.buttonlabel.html('Loading...');
+					self.button.addClass('ui-autocomplete-loading') 
+				},
+				complete: function() { 
+					self.buttonlabel.html(self.options.noneSelectedText);
+					self.button.removeClass('ui-autocomplete-loading') 
+				}
 			});
 		}
 		else if (typeof s == "function") {

--- a/tests/unit/index.htm
+++ b/tests/unit/index.htm
@@ -30,6 +30,7 @@
 
 <script type="text/javascript" src="http://code.jquery.com/jquery-1.7.js"></script>
 <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.js"></script>
+<script type="text/javascript" src="../../lib/jquery.mockjax.js"></script>
 <script type="text/javascript" src="../../src/jquery.multiselect.js"></script>
 <script type="text/javascript" src="../../src/jquery.multiselect.filter.js"></script>
 <script type="text/javascript" src="qunit.js"></script>

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -303,5 +303,70 @@
 		
 		el.multiselect("destroy");
 	});
+
+	test("source json url", function(){
+		expect(2);
+		$.mockjax({
+  			url: '/restful/foo.json',
+			  responseTime: 250,
+			  responseText: [ {id : '123', value: 'alice'}, {id: 456, value: 'bob'} ]
+		});
+		el = $("select").multiselect({ source: '/restful/foo.json' });
+		el.multiselect("open");
+		stop();
+		setTimeout(function() {  
+        	equals(1, $('option[value="123"]').length, "option with value 123 should exist.");
+        	equals(1, $('option[value="456"]').length, "option with value 456 should exist.");
+			$('option[value="123"]').remove();
+			$('option[value="456"]').remove();
+			el.multiselect("destroy");
+        	start();  
+    	}, 500);  
+	});
+
+	test("source json url with custom value desc attributes", function(){
+		expect(2);
+		$.mockjax({
+  			url: '/restful/custom.json',
+			  responseTime: 250,
+			  responseText: [ {res_id : 1420, name: 'alice'}, {res_id: 1520, name: 'bob'} ]
+		});
+		el = $("select").multiselect({ 
+			source: '/restful/custom.json',
+			descAttribute: 'name',
+			valueAttribute: 'res_id' 
+		});
+		el.multiselect("open");
+		stop();
+		setTimeout(function() {  
+        	equals(1, $('option[value="1420"]').length, "option with value 1420 should exist.");
+        	equals(1, $('option[value="1520"]').length, "option with value 1520 should exist.");
+			$('option[value="1420"]').remove();
+			$('option[value="1520"]').remove();
+			el.multiselect("destroy");
+        	start();  
+    	}, 500);  
+	});
+
+	test("server error handled correctly", function() {
+		expect(2);
+		$.mockjax({
+  			url: '/restful/error.json',
+  			status: 500,
+  			responseTime: 250,
+  			responseText: 'A text response from the server'
+		});
+		el = $("select").multiselect({ source: '/restful/error.json' });
+		el.multiselect("open");
+		stop();
+		setTimeout(function() {  
+        	equals(0, $('option[value="123"]').length, "option with value 123 should not exist.");
+        	equals(0, $('option[value="456"]').length, "option with value 456 should not exist.");
+        	el.multiselect("destroy");
+        	start();  
+    	}, 500); 
+	});
+
+
 	
 })(jQuery);

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -324,6 +324,21 @@
     	}, 500);  
 	});
 
+	test("source callback", function(){
+		expect(2);
+		el = $("select").multiselect({ 
+			source: function() { 
+				return [{ id: 123, value: 'alice'}, {id: 456, value: 'bob'}]
+			} 
+		});
+		el.multiselect("open");
+        equals(1, $('option[value="123"]').length, "option with value 123 should exist.");
+        equals(1, $('option[value="456"]').length, "option with value 456 should exist.");
+		$('option[value="123"]').remove();
+		$('option[value="456"]').remove();
+		el.multiselect("destroy"); 
+	});
+
 	test("source json url with custom value desc attributes", function(){
 		expect(2);
 		$.mockjax({
@@ -348,7 +363,7 @@
     	}, 500);  
 	});
 
-	test("server error handled correctly", function() {
+	test("source server error handled correctly", function() {
 		expect(2);
 		$.mockjax({
   			url: '/restful/error.json',


### PR DESCRIPTION
This pull request adds support for loading multiselect data lazily, either via AJAX or a callback function. The data is loaded once the multiselect is clicked on for the first time. The data format is assumed to be JSON, although it would be relatively straightforward to add support for XML datasources as well.

I've added qunit tests for the new functionality as well. Let me know if there's anything that's missing. I've also added a lib - mockjax - which I use to mock ajax calls on the unit tests.
