### PR TITLE
Fix IE JS Error if first item is disabled

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -571,7 +571,7 @@
       // show the menu, maybe with a speed/effect combo
       $.fn.show.apply(menu, args);
 
-      // select the first option
+      // select the first not disabled option
       // triggering both mouseover and mouseover because 1.4.2+ has a bug where triggering mouseover
       // will actually trigger mouseenter.  the mouseenter trigger is there for when it's eventually fixed
       this.labels.filter(':not(.ui-state-disabled)').eq(0).trigger('mouseover').trigger('mouseenter').find('input').trigger('focus');


### PR DESCRIPTION
If the first item is disabled, it cannot be focused. This raises a
JS error in IE8 (and probably other versions).

Make sure we find the first item that is not disabled and focus this.
