### PR TITLE
overflow-y set to auto

### DIFF
--- a/jquery.multiselect.css
+++ b/jquery.multiselect.css
@@ -12,7 +12,7 @@
 .ui-multiselect-header li.ui-multiselect-close { float:right; text-align:right; padding-right:0 }
 
 .ui-multiselect-menu { display:none; padding:3px; position:absolute; z-index:10000; text-align: left }
-.ui-multiselect-checkboxes { position:relative /* fixes bug in IE6/7 */; overflow-y:scroll }
+.ui-multiselect-checkboxes { position:relative /* fixes bug in IE6/7 */; overflow-y:auto }
 .ui-multiselect-checkboxes label { cursor:default; display:block; border:1px solid transparent; padding:3px 1px }
 .ui-multiselect-checkboxes label input { position:relative; top:1px }
 .ui-multiselect-checkboxes li { clear:both; font-size:0.9em; padding-right:3px }


### PR DESCRIPTION
the scrollbar is redundant if there are only a few elements to select - especially if you set "height: 'auto'" it is odd, since there is no scrollbar needed at all
