### PR TITLE
closeOnSelect Option

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -39,6 +39,7 @@
       show: null,
       hide: null,
       autoOpen: false,
+      closeOnSelect:false,
       multiple: true,
       position: {}
     },
@@ -382,7 +383,7 @@
         });
 
         // some additional single select-specific logic
-        if(!self.options.multiple) {
+        if(!self.options.multiple || self.options.closeOnSelect) {
           self.labels.removeClass('ui-state-active');
           $this.closest('label').toggleClass('ui-state-active', checked);
 


### PR DESCRIPTION
Added the option closeOnSelect that closes a multiselect when the user selects an option, even if the multiple:true option has been set.
