### PR TITLE
RTL support css files and Persian(Farsi) i18n

### DIFF
--- a/i18n/jquery.multiselect.fa.js
+++ b/i18n/jquery.multiselect.fa.js
@@ -1,0 +1,13 @@
+/* Persian(Farsi) initialisation for the jQuery UI multiselect plugin. */
+/* Written by Ghasem Shahabi (ghasem.shahabi@gmail.com). */
+
+(function ( $ ) {
+
+$.extend($.ech.multiselect.prototype.options, {
+  checkAllText: 'همه',
+  uncheckAllText: 'هيچكدام',
+  noneSelectedText: 'انتخاب كنيد',
+  selectedText: '# مورد انتخاب شده'
+});
+	
+})( jQuery );

--- a/i18n/jquery.multiselect.filter.fa.js
+++ b/i18n/jquery.multiselect.filter.fa.js
@@ -1,0 +1,11 @@
+/* Persian(Farsi) initialisation for the jQuery UI multiselect plugin. */
+/* Written by Ghasem Shahabi (ghasem.shahabi@gmail.com). */
+
+(function ( $ ) {
+
+$.extend($.ech.multiselectfilter.prototype.options, {
+  label: "فيلتر:",
+  placeholder: "كلمات كليدي"
+});
+
+})( jQuery );

--- a/jquery.multiselect.rtl.css
+++ b/jquery.multiselect.rtl.css
@@ -1,0 +1,7 @@
+.ui-multiselect { direction:rtl; text-align:right; padding:2px 4px 2px 0px; }
+.ui-multiselect span.ui-icon { float:left; }
+.ui-multiselect-checkboxes { direction: rtl; text-align: right; }
+.ui-multiselect-single .ui-multiselect-checkboxes input { right:-9999px; }
+.ui-multiselect-menu .ui-state-hover { font-weight: normal; }
+button.ui-state-default { font-weight: normal; }
+.ui-multiselect-filter { direction: ltr; }


### PR DESCRIPTION
To support Right-to-Left, I'm just including the rtl css file after main
css files to overwrite the Left-to-Right css(default), but it'd be
better if we have an rtl option in the widget. it's just working fine ;)