### PR TITLE
Fix id duplication

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -129,7 +129,7 @@
       var checkboxContainer = this.checkboxContainer;
       var optgroups = [];
       var html = "";
-      var id = el.attr('id') || multiselectID; // unique ID for the label & option tags
+      var id = el.attr('id') || multiselectID++; // unique ID for the label & option tags
 
       // build items
       el.find('option').each(function(i) {


### PR DESCRIPTION
Unique IDs weren't so unique.

In some situations with multiple selects on the same page this even leads to clicking one checkbox triggering another checkbox from another select! But this only happens after a call to `.multiselect("refresh")`, since then ids are duplicated. So is not easy to spot in testing.

See http://jsfiddle.net/ppzNK/ for id duplication (checkboxes from both selects have the same ids).
