### PR TITLE
Fix positioning when the position 'of' option is not set

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -661,7 +661,7 @@
 
       // use the position utility if it exists and options are specifified
       if($.ui.position && !$.isEmptyObject(o.position)) {
-        o.position.of = o.position.of || button;
+        o.position.of = o.position.of || this.button;
 
         this.menu
           .show()


### PR DESCRIPTION
If you use the position option but don't have 'of' specified, it tries to fallback to an undeclared variable. This lets it fallback to the correct variable.
