### PR TITLE
 'appendMenuTo' option 

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -40,7 +40,8 @@
       hide: null,
       autoOpen: false,
       multiple: true,
-      position: {}
+      position: {},
+      appendTo: document.body
     },
 
     _create: function() {
@@ -68,7 +69,7 @@
         menu = (this.menu = $('<div />'))
           .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all')
           .addClass(o.classes)
-          .appendTo(document.body),
+          .appendTo(o.appendMenuTo),
 
         header = (this.header = $('<div />'))
           .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')


### PR DESCRIPTION
Add the 'appendMenuTo' option, to enable appending the menu to some other 
parent element, other than the document's body.
This is very helpful when trying to apply specific CSS or behavior to the menu. 
