### PR TITLE
Allow space to select

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -350,6 +350,7 @@
             self._traverse(e.which, this);
           break;
           case 13: // enter
+          case 32: // space
             $(this).find('input')[0].click();
           break;
         }

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -40,6 +40,7 @@
       hide: null,
       autoOpen: false,
       multiple: true,
+      selectOnSpace: false,
       position: {},
       appendTo: "body"
     },
@@ -350,8 +351,12 @@
             self._traverse(e.which, this);
           break;
           case 13: // enter
-          case 32: // space
             $(this).find('input')[0].click();
+          break;
+          case 32: // space
+            if ( self.options.selectOnSpace == true ) {
+                $( this ).find( 'input' )[0].click();
+            }
           break;
         }
       })
@@ -727,6 +732,9 @@
           this.options.multiple = value;
           this.element[0].multiple = value;
           this.refresh();
+          break;
+        case 'selectOnSpace':
+          this.options.selectOnSpace = !!value;
           break;
         case 'position':
           this.position();

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -736,7 +736,7 @@
           this.refresh();
           break;
         case 'selectOnSpace':
-          this.options.selectOnSpace = !!value;
+          this.options[key] = !!value;
           break;
         case 'position':
           this.position();

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -361,7 +361,9 @@
         }
       })
       .delegate('label', 'keyup.multiselect', function(e) {
-          e.preventDefault();
+          if ( self.options.selectOnSpace == true ) {
+              e.preventDefault();
+          }
       })
       .delegate('input[type="checkbox"], input[type="radio"]', 'click.multiselect', function(e) {
         var $this = $(this);


### PR DESCRIPTION
We added the ability to select items via space, and disabled keyup events to prevent bouncing because firefox seemed to read on its own unlike the other browsers, and we are catching "real" expected events in keydown.
