### PR TITLE
Based on documentation, in prevAll and nextAll, we always want the first...

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -447,7 +447,7 @@
       var moveToLast = which === 38 || which === 37;
 
       // select the first li that isn't an optgroup label / disabled
-      var $next = $start.parent()[moveToLast ? 'prevAll' : 'nextAll']('li:not(.ui-multiselect-disabled, .ui-multiselect-optgroup-label)')[ moveToLast ? 'last' : 'first']();
+      var $next = $start.parent()[moveToLast ? 'prevAll' : 'nextAll']('li:not(.ui-multiselect-disabled, .ui-multiselect-optgroup-label)').first();
 
       // if at the first/last element
       if(!$next.length) {


### PR DESCRIPTION
As is now, pressing up always returns to the first item which is unintuitive.

This patch allows scrolling up and down as a user would expect, and still provides looping, so as far as we can tell nothing is lost and only features gained here.
