### PR TITLE
Group Features - Collapsible and Filterable

### DIFF
--- a/demos/groups.htm
+++ b/demos/groups.htm
@@ -1,0 +1,68 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<title>jQuery MultiSelect Widget Demo</title>
+<link rel="stylesheet" type="text/css" href="../jquery.multiselect.css" />
+<link rel="stylesheet" type="text/css" href="../jquery.multiselect.filter.css" />
+<link rel="stylesheet" type="text/css" href="assets/style.css" />
+<link rel="stylesheet" type="text/css" href="assets/prettify.css" />
+<link rel="stylesheet" type="text/css" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/ui-lightness/jquery-ui.css" />
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"></script>
+<script type="text/javascript" src="../src/jquery.multiselect.js"></script>
+<script type="text/javascript" src="assets/prettify.js"></script>
+<script type="text/javascript">
+  $(function () {
+
+    var $widget = $("select").multiselect(), state = true;
+    $("#toggle-collapsed").click(function () {
+      state = !state;
+      $widget.multiselect(state ? 'expandAll' : 'collapseAll').multiselect('open');
+    });
+
+  });
+</script>
+</head>
+<body onload="prettyPrint();">
+
+<h2>Collapse Groups</h2>
+
+<pre class="prettyprint">
+var $widget = $("select").multiselect(), state = true;
+$("#toggle-collapsed").click(function () {
+  state = !state;
+  $widget.multiselect(state ? 'expandAll' : 'collapseAll').multiselect('open');
+});
+</pre>
+
+<p style="margin-top:5px"><button type="button" name="toggle" id="toggle-collapsed">Toggle Collapsed</button></p>
+
+<form style="margin:20px 0">
+	<p>
+		<select multiple="multiple" style="width:370px">
+		<optgroup label="test">
+			<option value="red">Red</option>
+			<option value="green">Green</option>
+			<option value="blue">Blue</option>
+		</optgroup>
+		<optgroup label="foo">
+			<option value="orange">Orange</option>
+			<option value="purple">Purple</option>
+			<option value="yellow">Yellow</option>
+			<option value="brown">Brown</option>
+			<option value="black">Black</option>
+		</optgroup>
+		</select>
+	</p>
+</form>
+
+<script type="text/javascript">
+  $("select").multiselect({
+    'header': '<ul class="ui-helper-reset"><li><a href="#" onclick="$(\'select\').multiselect(\'collapseAll\'); return false"><span class="ui-icon ui-icon ui-icon-triangle-1-e"></span><span>Collapse</span></a></li> ' +
+              '<li><a href="#" onclick="$(\'select\').multiselect(\'expandAll\'); return false;"><span class="ui-icon ui-icon ui-icon-triangle-1-s"></span><span>Expand</span></a></li></ul>'
+  });
+</script>
+
+</body>
+</html>

--- a/jquery.multiselect.css
+++ b/jquery.multiselect.css
@@ -11,13 +11,16 @@
 .ui-multiselect-header span.ui-icon { float:left }
 .ui-multiselect-header li.ui-multiselect-close { float:right; text-align:right; padding-right:0 }
 
-.ui-multiselect-menu { display:none; padding:3px; position:absolute; z-index:10000; text-align: left }
+.ui-multiselect-menu { display:none; padding:3px; position:absolute; z-index:10000; }
 .ui-multiselect-checkboxes { position:relative /* fixes bug in IE6/7 */; overflow-y:auto }
 .ui-multiselect-checkboxes label { cursor:default; display:block; border:1px solid transparent; padding:3px 1px }
 .ui-multiselect-checkboxes label input { position:relative; top:1px }
 .ui-multiselect-checkboxes li { clear:both; font-size:0.9em; padding-right:3px }
-.ui-multiselect-checkboxes li.ui-multiselect-optgroup-label { text-align:center; font-weight:bold; border-bottom:1px solid }
-.ui-multiselect-checkboxes li.ui-multiselect-optgroup-label a { display:block; padding:3px; margin:1px 0; text-decoration:none }
+.ui-multiselect-checkboxes li.ui-multiselect-collapsed { display:none }
+.ui-multiselect-checkboxes li.ui-multiselect-filtered { display:none }
+.ui-multiselect-checkboxes li.ui-multiselect-optgroup-label { text-align:center; font-weight:bold; border-bottom:1px solid; position:relative; }
+.ui-multiselect-checkboxes li.ui-multiselect-optgroup-label a { display:block; padding:3px; margin:1px 0 0 16px; text-decoration:none; }
+.ui-multiselect-checkboxes li.ui-multiselect-optgroup-label span.ui-icon { position: absolute;left: 0;top: 50%;margin-top: -8px; }
 
 /* remove label borders in IE6 because IE6 does not support transparency */
 * html .ui-multiselect-checkboxes label { border:none }

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -334,18 +334,8 @@
         });
       })
       .delegate('li.ui-multiselect-optgroup-label span.ui-icon', 'click.multiselect', function (e) {
-        var icons = self.options.icons;
-        var $this = $(this)
-        if ($this.hasClass(icons.activeHeader)) {
-          //Collapse
-          $this.removeClass(icons.activeHeader).addClass(icons.header);
-          $this.parent().nextUntil('li.ui-multiselect-optgroup-label').addClass("ui-multiselect-collapsed");
-        } else {
-          //Expand
-          $this.removeClass(icons.header).addClass(icons.activeHeader);
-          $this.parent().nextUntil('li.ui-multiselect-optgroup-label').removeClass("ui-multiselect-collapsed");
-        }
-
+        var $this = $(this);
+        self._toggleCollapsed($this.hasClass(self.options.icons.activeHeader), $this);
       })
       .delegate('label', 'mouseenter.multiselect', function () {
         if (!$(this).hasClass('ui-state-disabled')) {
@@ -559,6 +549,23 @@
       });
     },
 
+    _toggleCollapsed: function (flag, group) {
+      var groups = (group && group.length) ? group : this.menu.find("li.ui-multiselect-optgroup-label span.ui-icon");
+      var icons = this.options.icons;
+
+      if (flag) {
+        //Collapse
+        groups
+                    .removeClass(icons.activeHeader).addClass(icons.header)
+                    .parent().nextUntil('li.ui-multiselect-optgroup-label').addClass("ui-multiselect-collapsed");
+      } else {
+        //Expand
+        groups
+                    .removeClass(icons.header).addClass(icons.activeHeader)
+                    .parent().nextUntil('li.ui-multiselect-optgroup-label').removeClass("ui-multiselect-collapsed");
+      }
+    },
+
     // open the menu
     open: function (e) {
       var self = this;
@@ -680,6 +687,16 @@
 
     getButton: function () {
       return this.button;
+    },
+
+    collapseAll: function () {
+      this._toggleCollapsed(true)
+      return this;
+    },
+
+    expandAll: function () {
+      this._toggleCollapsed(false)
+      return this;
     },
 
     position: function () {

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -18,7 +18,7 @@
  *   http://www.gnu.org/licenses/gpl.html
  *
  */
-(function($, undefined) {
+(function ($, undefined) {
 
   var multiselectID = 0;
   var $doc = $(document);
@@ -41,10 +41,14 @@
       autoOpen: false,
       multiple: true,
       position: {},
-      appendTo: "body"
+      appendTo: "body",
+      icons: {
+        activeHeader: "ui-icon-triangle-1-s",
+        header: "ui-icon-triangle-1-e"
+      }
     },
 
-    _create: function() {
+    _create: function () {
       var el = this.element.hide();
       var o = this.options;
 
@@ -59,7 +63,7 @@
       var button = (this.button = $('<button type="button"><span class="ui-icon ui-icon-triangle-1-s"></span></button>'))
         .addClass('ui-multiselect ui-widget ui-state-default ui-corner-all')
         .addClass(o.classes)
-        .attr({ 'title':el.attr('title'), 'aria-haspopup':true, 'tabIndex':el.attr('tabIndex') })
+        .attr({ 'title': el.attr('title'), 'aria-haspopup': true, 'tabIndex': el.attr('tabIndex') })
         .insertAfter(el),
 
         buttonlabel = (this.buttonlabel = $('<span />'))
@@ -77,10 +81,10 @@
 
         headerLinkContainer = (this.headerLinkContainer = $('<ul />'))
           .addClass('ui-helper-reset')
-          .html(function() {
-            if(o.header === true) {
+          .html(function () {
+            if (o.header === true) {
               return '<li><a class="ui-multiselect-all" href="#"><span class="ui-icon ui-icon-check"></span><span>' + o.checkAllText + '</span></a></li><li><a class="ui-multiselect-none" href="#"><span class="ui-icon ui-icon-closethick"></span><span>' + o.uncheckAllText + '</span></a></li>';
-            } else if(typeof o.header === "string") {
+            } else if (typeof o.header === "string") {
               return '<li>' + o.header + '</li>';
             } else {
               return '';
@@ -93,37 +97,37 @@
           .addClass('ui-multiselect-checkboxes ui-helper-reset')
           .appendTo(menu);
 
-        // perform event bindings
-        this._bindEvents();
+      // perform event bindings
+      this._bindEvents();
 
-        // build menu
-        this.refresh(true);
+      // build menu
+      this.refresh(true);
 
-        // some addl. logic for single selects
-        if(!o.multiple) {
-          menu.addClass('ui-multiselect-single');
-        }
+      // some addl. logic for single selects
+      if (!o.multiple) {
+        menu.addClass('ui-multiselect-single');
+      }
 
-        // bump unique ID
-        multiselectID++;
+      // bump unique ID
+      multiselectID++;
     },
 
-    _init: function() {
-      if(this.options.header === false) {
+    _init: function () {
+      if (this.options.header === false) {
         this.header.hide();
       }
-      if(!this.options.multiple) {
+      if (!this.options.multiple) {
         this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
       }
-      if(this.options.autoOpen) {
+      if (this.options.autoOpen) {
         this.open();
       }
-      if(this.element.is(':disabled')) {
+      if (this.element.is(':disabled')) {
         this.disable();
       }
     },
 
-    refresh: function(init) {
+    refresh: function (init) {
       var el = this.element;
       var o = this.options;
       var menu = this.menu;
@@ -133,7 +137,7 @@
       var id = el.attr('id') || multiselectID++; // unique ID for the label & option tags
 
       // build items
-      el.find('option').each(function(i) {
+      el.find('option').each(function (i) {
         var $this = $(this);
         var parent = this.parentNode;
         var description = this.innerHTML;
@@ -142,28 +146,28 @@
         var inputID = 'ui-multiselect-' + (this.id || id + '-option-' + i);
         var isDisabled = this.disabled;
         var isSelected = this.selected;
-        var labelClasses = [ 'ui-corner-all' ];
+        var labelClasses = ['ui-corner-all'];
         var liClasses = (isDisabled ? 'ui-multiselect-disabled ' : ' ') + this.className;
         var optLabel;
 
         // is this an optgroup?
-        if(parent.tagName === 'OPTGROUP') {
+        if (parent.tagName === 'OPTGROUP') {
           optLabel = parent.getAttribute('label');
 
           // has this optgroup been added already?
-          if($.inArray(optLabel, optgroups) === -1) {
-            html += '<li class="ui-multiselect-optgroup-label ' + parent.className + '"><a href="#">' + optLabel + '</a></li>';
+          if ($.inArray(optLabel, optgroups) === -1) {
+            html += '<li class="ui-multiselect-optgroup-label"><span class="ui-multiselect-header-icon ui-icon ' + o.icons.activeHeader + '"></span><a href="#">' + optLabel + '</a></li>';
             optgroups.push(optLabel);
           }
         }
 
-        if(isDisabled) {
+        if (isDisabled) {
           labelClasses.push('ui-state-disabled');
         }
 
         // browsers automatically select the first option
         // by default with single selects
-        if(isSelected && !o.multiple) {
+        if (isSelected && !o.multiple) {
           labelClasses.push('ui-state-active');
         }
 
@@ -174,13 +178,13 @@
         html += '<input id="' + inputID + '" name="multiselect_' + id + '" type="' + (o.multiple ? "checkbox" : "radio") + '" value="' + value + '" title="' + title + '"';
 
         // pre-selected?
-        if(isSelected) {
+        if (isSelected) {
           html += ' checked="checked"';
           html += ' aria-selected="true"';
         }
 
         // disabled?
-        if(isDisabled) {
+        if (isDisabled) {
           html += ' disabled="disabled"';
           html += ' aria-disabled="true"';
         }
@@ -204,26 +208,26 @@
       this.button[0].defaultValue = this.update();
 
       // broadcast refresh event; useful for widgets
-      if(!init) {
+      if (!init) {
         this._trigger('refresh');
       }
     },
 
     // updates the button text. call refresh() to rebuild
-    update: function() {
+    update: function () {
       var o = this.options;
       var $inputs = this.inputs;
       var $checked = $inputs.filter(':checked');
       var numChecked = $checked.length;
       var value;
 
-      if(numChecked === 0) {
+      if (numChecked === 0) {
         value = o.noneSelectedText;
       } else {
-        if($.isFunction(o.selectedText)) {
+        if ($.isFunction(o.selectedText)) {
           value = o.selectedText.call(this, numChecked, $inputs.length, $checked.get());
-        } else if(/\d/.test(o.selectedList) && o.selectedList > 0 && numChecked <= o.selectedList) {
-          value = $checked.map(function() { return $(this).next().html(); }).get().join(', ');
+        } else if (/\d/.test(o.selectedList) && o.selectedList > 0 && numChecked <= o.selectedList) {
+          value = $checked.map(function () { return $(this).next().html(); }).get().join(', ');
         } else {
           value = o.selectedText.replace('#', numChecked).replace('#', $inputs.length);
         }
@@ -236,17 +240,17 @@
 
     // this exists as a separate method so that the developer 
     // can easily override it.
-    _setButtonValue: function(value) {
+    _setButtonValue: function (value) {
       this.buttonlabel.text(value);
     },
 
     // binds events
-    _bindEvents: function() {
+    _bindEvents: function () {
       var self = this;
       var button = this.button;
 
       function clickHandler() {
-        self[ self._isOpen ? 'close' : 'open' ]();
+        self[self._isOpen ? 'close' : 'open']();
         return false;
       }
 
@@ -258,41 +262,41 @@
       // button events
       button.bind({
         click: clickHandler,
-        keypress: function(e) {
-          switch(e.which) {
+        keypress: function (e) {
+          switch (e.which) {
             case 27: // esc
-              case 38: // up
-              case 37: // left
+            case 38: // up
+            case 37: // left
               self.close();
-            break;
+              break;
             case 39: // right
-              case 40: // down
+            case 40: // down
               self.open();
-            break;
+              break;
           }
         },
-        mouseenter: function() {
-          if(!button.hasClass('ui-state-disabled')) {
+        mouseenter: function () {
+          if (!button.hasClass('ui-state-disabled')) {
             $(this).addClass('ui-state-hover');
           }
         },
-        mouseleave: function() {
+        mouseleave: function () {
           $(this).removeClass('ui-state-hover');
         },
-        focus: function() {
-          if(!button.hasClass('ui-state-disabled')) {
+        focus: function () {
+          if (!button.hasClass('ui-state-disabled')) {
             $(this).addClass('ui-state-focus');
           }
         },
-        blur: function() {
+        blur: function () {
           $(this).removeClass('ui-state-focus');
         }
       });
 
       // header links
-      this.header.delegate('a', 'click.multiselect', function(e) {
+      this.header.delegate('a', 'click.multiselect', function (e) {
         // close link
-        if($(this).hasClass('ui-multiselect-close')) {
+        if ($(this).hasClass('ui-multiselect-close')) {
           self.close();
 
           // check all / uncheck all
@@ -304,16 +308,16 @@
       });
 
       // optgroup label toggle support
-      this.menu.delegate('li.ui-multiselect-optgroup-label a', 'click.multiselect', function(e) {
+      this.menu.delegate('li.ui-multiselect-optgroup-label a', 'click.multiselect', function (e) {
         e.preventDefault();
 
         var $this = $(this);
-        var $inputs = $this.parent().nextUntil('li.ui-multiselect-optgroup-label').find('input:visible:not(:disabled)');
+        var $inputs = $this.parent().nextUntil('li.ui-multiselect-optgroup-label').filter(':not(.ui-multiselect-filtered)').find('input:not(:disabled)');
         var nodes = $inputs.get();
         var label = $this.parent().text();
 
         // trigger event and bail if the return is false
-        if(self._trigger('beforeoptgrouptoggle', e, { inputs:nodes, label:label }) === false) {
+        if (self._trigger('beforeoptgrouptoggle', e, { inputs: nodes, label: label }) === false) {
           return;
         }
 
@@ -329,39 +333,53 @@
           checked: nodes[0].checked
         });
       })
-      .delegate('label', 'mouseenter.multiselect', function() {
-        if(!$(this).hasClass('ui-state-disabled')) {
+      .delegate('li.ui-multiselect-optgroup-label span.ui-icon', 'click.multiselect', function (e) {
+        var icons = self.options.icons;
+        var $this = $(this)
+        if ($this.hasClass(icons.activeHeader)) {
+          //Collapse
+          $this.removeClass(icons.activeHeader).addClass(icons.header);
+          $this.parent().nextUntil('li.ui-multiselect-optgroup-label').addClass("ui-multiselect-collapsed");
+        } else {
+          //Expand
+          $this.removeClass(icons.header).addClass(icons.activeHeader);
+          $this.parent().nextUntil('li.ui-multiselect-optgroup-label').removeClass("ui-multiselect-collapsed");
+        }
+
+      })
+      .delegate('label', 'mouseenter.multiselect', function () {
+        if (!$(this).hasClass('ui-state-disabled')) {
           self.labels.removeClass('ui-state-hover');
           $(this).addClass('ui-state-hover').find('input').focus();
         }
       })
-      .delegate('label', 'keydown.multiselect', function(e) {
+      .delegate('label', 'keydown.multiselect', function (e) {
         e.preventDefault();
 
-        switch(e.which) {
+        switch (e.which) {
           case 9: // tab
-            case 27: // esc
+          case 27: // esc
             self.close();
-          break;
+            break;
           case 38: // up
-            case 40: // down
-            case 37: // left
-            case 39: // right
+          case 40: // down
+          case 37: // left
+          case 39: // right
             self._traverse(e.which, this);
-          break;
+            break;
           case 13: // enter
             $(this).find('input')[0].click();
-          break;
+            break;
         }
       })
-      .delegate('input[type="checkbox"], input[type="radio"]', 'click.multiselect', function(e) {
+      .delegate('input[type="checkbox"], input[type="radio"]', 'click.multiselect', function (e) {
         var $this = $(this);
         var val = this.value;
         var checked = this.checked;
         var tags = self.element.find('option');
 
         // bail if this input is disabled or the event is cancelled
-        if(this.disabled || self._trigger('click', e, { value: val, text: this.title, checked: checked }) === false) {
+        if (this.disabled || self._trigger('click', e, { value: val, text: this.title, checked: checked }) === false) {
           e.preventDefault();
           return;
         }
@@ -374,16 +392,16 @@
         $this.attr('aria-selected', checked);
 
         // change state on the original option tags
-        tags.each(function() {
-          if(this.value === val) {
+        tags.each(function () {
+          if (this.value === val) {
             this.selected = checked;
-          } else if(!self.options.multiple) {
+          } else if (!self.options.multiple) {
             this.selected = false;
           }
         });
 
         // some additional single select-specific logic
-        if(!self.options.multiple) {
+        if (!self.options.multiple) {
           self.labels.removeClass('ui-state-active');
           $this.closest('label').toggleClass('ui-state-active', checked);
 
@@ -400,10 +418,10 @@
       });
 
       // close each widget when clicking on any other element/anywhere else on the page
-      $doc.bind('mousedown.' + this._namespaceID, function(event) {
+      $doc.bind('mousedown.' + this._namespaceID, function (event) {
         var target = event.target;
 
-        if(self._isOpen
+        if (self._isOpen
             && target !== self.button[0]
             && target !== self.menu[0]
             && !$.contains(self.menu[0], target)
@@ -417,17 +435,17 @@
       // restored to their defaultValue prop on form reset, and the reset
       // handler fires before the form is actually reset.  delaying it a bit
       // gives the form inputs time to clear.
-      $(this.element[0].form).bind('reset.multiselect', function() {
+      $(this.element[0].form).bind('reset.multiselect', function () {
         setTimeout($.proxy(self.refresh, self), 10);
       });
     },
 
     // set button width
-    _setButtonWidth: function() {
+    _setButtonWidth: function () {
       var width = this.element.outerWidth();
       var o = this.options;
 
-      if(/\d/.test(o.minWidth) && width < o.minWidth) {
+      if (/\d/.test(o.minWidth) && width < o.minWidth) {
         width = o.minWidth;
       }
 
@@ -436,13 +454,13 @@
     },
 
     // set menu width
-    _setMenuWidth: function() {
+    _setMenuWidth: function () {
       var m = this.menu;
       m.outerWidth(this.button.outerWidth());
     },
 
     // move up or down within the menu
-    _traverse: function(which, start) {
+    _traverse: function (which, start) {
       var $start = $(start);
       var moveToLast = which === 38 || which === 37;
 
@@ -450,11 +468,11 @@
       var $next = $start.parent()[moveToLast ? 'prevAll' : 'nextAll']('li:not(.ui-multiselect-disabled, .ui-multiselect-optgroup-label)').first();
 
       // if at the first/last element
-      if(!$next.length) {
+      if (!$next.length) {
         var $container = this.menu.find('ul').last();
 
         // move to the first/last
-        this.menu.find('label')[ moveToLast ? 'last' : 'first' ]().trigger('mouseover');
+        this.menu.find('label')[moveToLast ? 'last' : 'first']().trigger('mouseover');
 
         // set scroll position
         $container.scrollTop(moveToLast ? $container.height() : 0);
@@ -468,13 +486,13 @@
     // other related attributes of a checkbox.
     //
     // The context of this function should be a checkbox; do not proxy it.
-    _toggleState: function(prop, flag) {
-      return function() {
-        if(!this.disabled) {
-          this[ prop ] = flag;
+    _toggleState: function (prop, flag) {
+      return function () {
+        if (!this.disabled) {
+          this[prop] = flag;
         }
 
-        if(flag) {
+        if (flag) {
           this.setAttribute('aria-selected', true);
         } else {
           this.removeAttribute('aria-selected');
@@ -482,8 +500,8 @@
       };
     },
 
-    _toggleChecked: function(flag, group) {
-      var $inputs = (group && group.length) ?  group : this.inputs;
+    _toggleChecked: function (flag, group) {
+      var $inputs = (group && group.length) ? group : this.inputs;
       var self = this;
 
       // toggle state on inputs
@@ -496,53 +514,53 @@
       this.update();
 
       // gather an array of the values that actually changed
-      var values = $inputs.map(function() {
+      var values = $inputs.map(function () {
         return this.value;
       }).get();
 
       // toggle state on original option tags
       this.element
         .find('option')
-        .each(function() {
-          if(!this.disabled && $.inArray(this.value, values) > -1) {
+        .each(function () {
+          if (!this.disabled && $.inArray(this.value, values) > -1) {
             self._toggleState('selected', flag).call(this);
           }
         });
 
       // trigger the change event on the select
-      if($inputs.length) {
+      if ($inputs.length) {
         this.element.trigger("change");
       }
     },
 
-    _toggleDisabled: function(flag) {
-      this.button.attr({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
+    _toggleDisabled: function (flag) {
+      this.button.attr({ 'disabled': flag, 'aria-disabled': flag })[flag ? 'addClass' : 'removeClass']('ui-state-disabled');
 
       var inputs = this.menu.find('input');
       var key = "ech-multiselect-disabled";
 
-      if(flag) {
+      if (flag) {
         // remember which elements this widget disabled (not pre-disabled)
         // elements, so that they can be restored if the widget is re-enabled.
         inputs = inputs.filter(':enabled').data(key, true)
       } else {
-        inputs = inputs.filter(function() {
+        inputs = inputs.filter(function () {
           return $.data(this, key) === true;
         }).removeData(key);
       }
 
       inputs
-        .attr({ 'disabled':flag, 'arial-disabled':flag })
-        .parent()[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
+        .attr({ 'disabled': flag, 'arial-disabled': flag })
+        .parent()[flag ? 'addClass' : 'removeClass']('ui-state-disabled');
 
       this.element.attr({
-        'disabled':flag,
-        'aria-disabled':flag
+        'disabled': flag,
+        'aria-disabled': flag
       });
     },
 
     // open the menu
-    open: function(e) {
+    open: function (e) {
       var self = this;
       var button = this.button;
       var menu = this.menu;
@@ -551,7 +569,7 @@
       var args = [];
 
       // bail if the multiselectopen event returns false, this widget is disabled, or is already open
-      if(this._trigger('beforeopen') === false || button.hasClass('ui-state-disabled') || this._isOpen) {
+      if (this._trigger('beforeopen') === false || button.hasClass('ui-state-disabled') || this._isOpen) {
         return;
       }
 
@@ -559,15 +577,15 @@
       var effect = o.show;
 
       // figure out opening effects/speeds
-      if($.isArray(o.show)) {
+      if ($.isArray(o.show)) {
         effect = o.show[0];
         speed = o.show[1] || self.speed;
       }
 
       // if there's an effect, assume jQuery UI is in use
       // build the arguments to pass to show()
-      if(effect) {
-        args = [ effect, speed ];
+      if (effect) {
+        args = [effect, speed];
       }
 
       // set the scroll of the checkbox container
@@ -590,8 +608,8 @@
     },
 
     // close the menu
-    close: function() {
-      if(this._trigger('beforeclose') === false) {
+    close: function () {
+      if (this._trigger('beforeclose') === false) {
         return;
       }
 
@@ -601,13 +619,13 @@
       var args = [];
 
       // figure out opening effects/speeds
-      if($.isArray(o.hide)) {
+      if ($.isArray(o.hide)) {
         effect = o.hide[0];
         speed = o.hide[1] || this.speed;
       }
 
-      if(effect) {
-        args = [ effect, speed ];
+      if (effect) {
+        args = [effect, speed];
       }
 
       $.fn.hide.apply(this.menu, args);
@@ -616,29 +634,29 @@
       this._trigger('close');
     },
 
-    enable: function() {
+    enable: function () {
       this._toggleDisabled(false);
     },
 
-    disable: function() {
+    disable: function () {
       this._toggleDisabled(true);
     },
 
-    checkAll: function(e) {
+    checkAll: function (e) {
       this._toggleChecked(true);
       this._trigger('checkAll');
     },
 
-    uncheckAll: function() {
+    uncheckAll: function () {
       this._toggleChecked(false);
       this._trigger('uncheckAll');
     },
 
-    getChecked: function() {
+    getChecked: function () {
       return this.menu.find('input').filter(':checked');
     },
 
-    destroy: function() {
+    destroy: function () {
       // remove classes + data
       $.Widget.prototype.destroy.call(this);
 
@@ -652,23 +670,23 @@
       return this;
     },
 
-    isOpen: function() {
+    isOpen: function () {
       return this._isOpen;
     },
 
-    widget: function() {
+    widget: function () {
       return this.menu;
     },
 
-    getButton: function() {
+    getButton: function () {
       return this.button;
     },
 
-    position: function() {
+    position: function () {
       var o = this.options;
 
       // use the position utility if it exists and options are specifified
-      if($.ui.position && !$.isEmptyObject(o.position)) {
+      if ($.ui.position && !$.isEmptyObject(o.position)) {
         o.position.of = o.position.of || this.button;
 
         this.menu
@@ -688,10 +706,10 @@
     },
 
     // react to option changes after initialization
-    _setOption: function(key, value) {
+    _setOption: function (key, value) {
       var menu = this.menu;
 
-      switch(key) {
+      switch (key) {
         case 'header':
           menu.find('div.ui-multiselect-header')[value ? 'show' : 'hide']();
           break;


### PR DESCRIPTION
This implements two improvements for groups.

1) For the standard multiselect, I added a collapse / expand icon near each group. This causes the group to collapse, yet clicking on it in it's collapsed state will check / uncheck its children.
2) For the filter plugin, I added support to search by group name. If you type a group name, or part of it, all of its children will be displayed, even if the checkbox itself does not match.
