### PR TITLE
Empty text in ui object

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -137,7 +137,7 @@
         var $this = $(this);
         var parent = this.parentNode;
         var description = this.innerHTML;
-        var title = this.title;
+        var title = this.title||$this.text();
         var value = this.value;
         var inputID = 'ui-multiselect-' + (this.id || id + '-option-' + i);
         var isDisabled = this.disabled;


### PR DESCRIPTION
When you use callbacks and option tags doesn't have a title attribute, the field called 'text' in the ui object is empty. With this commit, if title attribute is empty, the text field is filled with the text of option tags.