### PR TITLE
make close icon configurable

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -36,6 +36,7 @@
       noneSelectedText: 'Select options',
       selectedText: '# selected',
       selectedList: 0,
+      selectedList: 'ui-icon-circle-close',
       show: null,
       hide: null,
       autoOpen: false,
@@ -86,7 +87,7 @@
               return '';
             }
           })
-          .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon ui-icon-circle-close"></span></a></li>')
+          .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon '+o.closeIcon+'"></span></a></li>')
           .appendTo(header),
 
         checkboxContainer = (this.checkboxContainer = $('<ul />'))

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -36,7 +36,7 @@
       noneSelectedText: 'Select options',
       selectedText: '# selected',
       selectedList: 0,
-      selectedList: 'ui-icon-circle-close',
+      closeIcon: 'ui-icon-circle-close',
       show: null,
       hide: null,
       autoOpen: false,

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -324,5 +324,11 @@
 		
 		el.multiselect("destroy");
 	});
-	
+	test("closeIcon", function(){
+		expect(1);
+		var icon = "ui-icon-search";
+		el = $("select").multiselect({ autoOpen:true, closeIcon:icon });
+		equals(menu().find(".ui-multiselect-close").find("."+icon).length, 1);
+		el.multiselect("destroy");
+	});
 })(jQuery);


### PR DESCRIPTION
The default close icon is very close to the clear icon, which can be confusing.  I've added an option to set the close icon to something else (I'm using ui-icon-search).