### PR TITLE
Adds a toggleInputs option to the enable/disable methods

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -515,25 +515,28 @@
       }
     },
 
-    _toggleDisabled: function(flag) {
+    _toggleDisabled: function(flag, toggleInputs) {
       this.button.attr({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
 
-      var inputs = this.menu.find('input');
-      var key = "ech-multiselect-disabled";
 
-      if(flag) {
-        // remember which elements this widget disabled (not pre-disabled)
-        // elements, so that they can be restored if the widget is re-enabled.
-        inputs = inputs.filter(':enabled').data(key, true)
-      } else {
-        inputs = inputs.filter(function() {
-          return $.data(this, key) === true;
-        }).removeData(key);
+      if(toggleInputs) {
+        var inputs = this.menu.find('input');
+        var key = "ech-multiselect-disabled";
+          
+        if(flag) {
+          // remember which elements this widget disabled (not pre-disabled)
+          // elements, so that they can be restored if the widget is re-enabled.
+          inputs = inputs.filter(':enabled').data(key, true)
+        } else {
+          inputs = inputs.filter(function() {
+            return $.data(this, key) === true;
+          }).removeData(key);
+        }
+
+        inputs
+          .attr({ 'disabled':flag, 'arial-disabled':flag })
+          .parent()[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
       }
-
-      inputs
-        .attr({ 'disabled':flag, 'arial-disabled':flag })
-        .parent()[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
 
       this.element.attr({
         'disabled':flag,
@@ -616,12 +619,12 @@
       this._trigger('close');
     },
 
-    enable: function() {
-      this._toggleDisabled(false);
+    enable: function(toggleInputs) {
+      this._toggleDisabled(false, toggleInputs === undefined ? true : toggleInputs);
     },
 
-    disable: function() {
-      this._toggleDisabled(true);
+    disable: function(toggleInputs) {
+      this._toggleDisabled(true, , toggleInputs === undefined ? true : toggleInputs);
     },
 
     checkAll: function(e) {


### PR DESCRIPTION
For select elements with a large number of options, Internet Explorer will freeze when enabling and disabling the multiselect. After looking at the code it appears that all of the option elements are being enabled and disabled as well. Since the main button is disabled it doesn't appear that the option elements always need to be disabled/enabled. For some implementations this may be an unnecessarily large DOM manipulation. 

Here's an example:
http://jsfiddle.net/akhyp/1496/

In Internet Explorer this could freeze the window for upwards of 30 seconds, just trying to disable the element. 

This fork allows the developer to choose whether or not we need to the toggle the inputs inside of the select element, which for us makes all the difference between using the disable functionality or rolling our own. The default behavior of toggling these elements is preserved, but the developer can additionally pass in a "falsey" value to opt out of toggling the inputs.
