### PR TITLE
Added option for setting custom menu width

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -41,7 +41,8 @@
       autoOpen: false,
       multiple: true,
       position: {},
-      appendTo: "body"
+      appendTo: "body",
+      menuWidth:null
     },
 
     _create: function() {
@@ -438,7 +439,7 @@
     // set menu width
     _setMenuWidth: function() {
       var m = this.menu;
-      m.outerWidth(this.button.outerWidth());
+      m.outerWidth(this.options.menuWidth || this.button.outerWidth());
     },
 
     // move up or down within the menu


### PR DESCRIPTION
Custom menu width can be used in case of lack of space for select, and long text in options.
Usage: $('select').multiselect({ minWidth: 100, menuWidth:250 });