### PR TITLE
Update jquery.multiselect.js to avoid jump scroll

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -22,6 +22,14 @@
 
   var multiselectID = 0;
   var $doc = $(document);
+  
+  function focusNoScroll(multiselectObject) {
+    //save the current window position, and restore it after the focus event. 
+    var x = window.scrollX, y = window.scrollY;
+    multiselectObject.trigger("focus");
+    window.scrollTo(x, y);
+    return multiselectObject; //chainability
+};
 
   $.widget("ech.multiselect", {
 
@@ -332,7 +340,9 @@
       .delegate('label', 'mouseenter.multiselect', function() {
         if(!$(this).hasClass('ui-state-disabled')) {
           self.labels.removeClass('ui-state-hover');
-          $(this).addClass('ui-state-hover').find('input').focus();
+          $(this).addClass('ui-state-hover');
+          var multiselectObject = $(this).find('input');
+          focusNoScroll(multiselectObject);
         }
       })
       .delegate('label', 'keydown.multiselect', function(e) {
@@ -582,7 +592,9 @@
       // select the first not disabled option
       // triggering both mouseover and mouseover because 1.4.2+ has a bug where triggering mouseover
       // will actually trigger mouseenter.  the mouseenter trigger is there for when it's eventually fixed
-      this.labels.filter(':not(.ui-state-disabled)').eq(0).trigger('mouseover').trigger('mouseenter').find('input').trigger('focus');
+      this.labels.filter(':not(.ui-state-disabled)').eq(0).trigger('mouseover').trigger('mouseenter').find('input');
+      var multiselectObject = this.labels;
+      focusNoScroll(multiselectObject);
 
       button.addClass('ui-state-active');
       this._isOpen = true;


### PR DESCRIPTION
Steps to reproduce the bug that this update fixes. - https://github.com/ehynds/jquery-ui-multiselect-widget/issues/551

Load page with SingleSelect element - for example - http://www.erichynds.com/examples/jquery-ui-multiselect-widget/demos/#single
Change browser window to very narrow
Scroll over to the left hand side.
Click single select element
Observe the page jumps back to the right hand side, or right aligned.
Screencast of bug on demo page - http://screencast.com/t/GUmkvIQzIg

Screencast of bug in our system (all info is standard fake Salesforce info) - http://screencast.com/t/xL3buTWvZ

This doesn't change behavior, keyboard events still work, focus is still given, but the page does not jump around.
