### PR TITLE
Allow the user to set the name of the checkbox

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -145,6 +145,7 @@
         var labelClasses = [ 'ui-corner-all' ];
         var liClasses = (isDisabled ? 'ui-multiselect-disabled ' : ' ') + this.className;
         var optLabel;
+        var optName = $this.attr('name');
 
         // is this an optgroup?
         if(parent.tagName === 'OPTGROUP') {
@@ -171,7 +172,7 @@
 
         // create the label
         html += '<label for="' + inputID + '" title="' + title + '" class="' + labelClasses.join(' ') + '">';
-        html += '<input id="' + inputID + '" name="multiselect_' + id + '" type="' + (o.multiple ? "checkbox" : "radio") + '" value="' + value + '" title="' + title + '"';
+        html += '<input id="' + inputID + '" name="'+(optName!=undefined?k:"multiselect_"+i)+'" type="' + (o.multiple ? "checkbox" : "radio") + '" value="' + value + '" title="' + title + '"';
 
         // pre-selected?
         if(isSelected) {


### PR DESCRIPTION
With this change the name attribute of the option will be the name of checkbox. If the option input do not has a name attribute, the plugin will put the default name (multiselect_i). It is useful to better control inputs.
