### PR TITLE
copy data-* attributes of options & optgroups

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -145,6 +145,15 @@
         var labelClasses = [ 'ui-corner-all' ];
         var liClasses = (isDisabled ? 'ui-multiselect-disabled ' : ' ') + this.className;
         var optLabel;
+		var getDataAttrs = function (allAttrs) {
+			// copy data-* attributes
+			return $.map(allAttrs, function (a) {
+				if (a.nodeType === 2 && a.nodeName.indexOf('data-') === 0) {
+					return ' ' + a.nodeName + '="' + a.nodeValue + '"';
+				}
+				return '';
+			}).join('');
+		}
 
         // is this an optgroup?
         if(parent.tagName === 'OPTGROUP') {
@@ -152,7 +161,7 @@
 
           // has this optgroup been added already?
           if($.inArray(optLabel, optgroups) === -1) {
-            html += '<li class="ui-multiselect-optgroup-label ' + parent.className + '"><a href="#">' + optLabel + '</a></li>';
+            html += '<li class="ui-multiselect-optgroup-label ' + parent.className + '"' + getDataAttrs(parent.attributes) + '><a href="#">' + optLabel + '</a></li>';
             optgroups.push(optLabel);
           }
         }
@@ -167,7 +176,7 @@
           labelClasses.push('ui-state-active');
         }
 
-        html += '<li class="' + liClasses + '">';
+        html += '<li class="' + liClasses + '"' + getDataAttrs(this.attributes) + '>';
 
         // create the label
         html += '<label for="' + inputID + '" title="' + title + '" class="' + labelClasses.join(' ') + '">';

--- a/tests/unit/html.js
+++ b/tests/unit/html.js
@@ -24,10 +24,25 @@
 
 	});
 
+	test("pull in optgroup's data-* attributes", function () {
+		var expected = $("select optgroup[data-test]")
+		expect(1);
+
+		elems = widget.find('.ui-multiselect-optgroup-label[data-test]');
+		equals(elems.length, expected.length, 'copied data-test attributes ' + expected.length + ' times.');
+	});
+
 	test("pull in options's class", function(){
 		expect(1);
 
 		equals(widget.find('input[value="9"]').parents('li:first').hasClass('optionClass'),true,'Extra class is present');
 	});
 
+	test("pull in options's data-* attributes", function () {
+		var expected = $("select option[data-test]")
+		expect(1);
+
+		elems = widget.find('li[data-test]:not(.ui-multiselect-optgroup-label)');
+		equals(elems.length, expected.length, 'copied data-test attributes ' + expected.length + ' times.');
+	});
 })(jQuery);

--- a/tests/unit/index.htm
+++ b/tests/unit/index.htm
@@ -15,10 +15,10 @@
 <ol id="qunit-tests"></ol>
 
 <select title="MultiSelect" multiple="multiple" tabindex="2">
-<optgroup label="Optgroup One">
-	<option value="1">One</option>
-	<option value="2">Two</option>
-	<option value="3">Three</option>
+<optgroup data-test="optgoup-test" label="Optgroup One">
+	<option data-test="value-A" value="1">One</option>
+	<option data-test="value-B" value="2">Two</option>
+	<option data-test="value-C" value="3">Three</option>
 </optgroup>
 <optgroup label="Optgroup two">
 	<option value="4">Four</option>


### PR DESCRIPTION
I needed the possibility to show/hide options dynamically and the site I'm currently working on relies somewhat on data-\* attributes instead of "functional classes".

So I needed the ability to copy data-\* attributes as well as classes from options and optgroups 
