### PR TITLE
Updated Unit Tests

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -137,7 +137,7 @@
         var $this = $(this);
         var parent = this.parentNode;
         var description = this.innerHTML;
-        var title = this.title;
+        var title = this.title === "" ? this.textContent : this.title;
         var value = this.value;
         var inputID = 'ui-multiselect-' + (this.id || id + '-option-' + i);
         var isDisabled = this.disabled;

--- a/tests/unit/index.htm
+++ b/tests/unit/index.htm
@@ -3,7 +3,7 @@
 <head>
 <title>jQuery UI MultiSelect Widget Unit Tests</title>
 <link rel="stylesheet" href="qunit.css" type="text/css" media="screen" />
-<link rel="stylesheet" href="http://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/base/jquery-ui.css" type="text/css" media="screen" />
+<link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="../../jquery.multiselect.css" type="text/css" media="screen" />
 <link rel="stylesheet" href="../../jquery.multiselect.filter.css" type="text/css" media="screen" />
 </head>
@@ -32,8 +32,8 @@
 </optgroup>
 </select>
 
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
-<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.0/jquery.min.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
 <script type="text/javascript" src="../../src/jquery.multiselect.js"></script>
 <script type="text/javascript" src="../../src/jquery.multiselect.filter.js"></script>
 <script type="text/javascript" src="qunit.js"></script>


### PR DESCRIPTION
Unit tests are now up to date and passing.

Index.html is referencing current libraries rather than base revisions. As per: http://stackoverflow.com/questions/12608242/latest-jquery-version-on-googles-cdn

Using the base revisions to get the latest library versions is no longer supported so we need to manually update these to the latest as they come along.

I set the title property to a sanitized version of the option elements text content if no title was initially provided. This is in line with the assertions in the unit tests.