### PR TITLE
When source data has display:none, hide the options

### DIFF
--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -164,11 +164,13 @@
     },
 
     updateCache: function() {
+
       // each list item
       this.rows = this.instance.menu.find(".ui-multiselect-checkboxes li:not(.ui-multiselect-optgroup-label)");
 
       // cache
-      this.cache = this.element.children().map(function() {
+      // Skip display-none rows
+      this.cache = this.element.children(":not(:css(display=none))").map(function() {
         var elem = $(this);
 
         // account for optgroups

--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -175,7 +175,7 @@
 
         // account for optgroups
         if(this.tagName.toLowerCase() === "optgroup") {
-          elem = elem.children();
+          elem = elem.children(":not(:css(display=none))");
         }
 
         return elem.map(function() {

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -19,6 +19,12 @@
  *
  */
 (function($, undefined) {
+  // http://stackoverflow.com/a/3640212/401636
+  // custom css filter ex: :css(display=none)
+  $.expr[':'].css = function(obj, index, meta, stack) {
+    var args = meta[3].split(/\s*=\s*/);
+    return $(obj).css(args[0]) == args[1];
+  }
 
   var multiselectID = 0;
   var $doc = $(document);
@@ -199,15 +205,17 @@
         }
       }
 
-      //Turn all the options and optiongroups into list items
-      el.children().each(function(i) {
+      // Turn all the options and optiongroups into list items
+      // hide display=none options and optiongroups
+      el.children(":not(:css(display=none))").each(function(i) {
         var $this = $(this);
 
         if(this.tagName === 'OPTGROUP') {
           var $groupLabel = $("<li/>").addClass('ui-multiselect-optgroup-label ' + this.className).appendTo($dropdown);
           var $link = $("<a/>").attr("href", "#").text(this.getAttribute('label')).appendTo($groupLabel);
 
-          $this.children().each(function() {
+          // hide display=none options
+          $this.children(":not(:css(display=none))").each(function() {
             var $listItem = makeItem(this, true).appendTo($dropdown);
           });
         } else {


### PR DESCRIPTION
When there is a long list of choices, it is valuable to show a checkbox that can hide some of the options. To be able to later show them again in their original location, the simplest approach is to use `.hide()` (which sets an inline style of `display:none`) on the `<option>` elements.

By looking specifically for this style (rather than `:is_visible`), we can hide these elements in the widget when calling `refresh()`

The filter addition must also ignore these elements when rebuilding it's cache

Sorry, I don't know how to create tests in javascript, but I'm using this small modification so I can hide/show various options in the widget by show/hiding the original data elements.