### PR TITLE
Multiple option elimination (redo of #719)

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -29,19 +29,19 @@
       height: 175,
       minWidth: 225,
       classes: '',
-      openIcon: '<span class="ui-icon ui-icon-triangle-1-s"></span>',   // Scaleable HTML Entities or Font-Awesome icons can be used here instead of the default jQuery UI icons.
+      openIcon: '<span class="ui-icon ui-icon-triangle-1-s"></span>',         // Scaleable HTML Entities or Font-Awesome icons can be used here instead of the default jQuery UI icons.
       closeIcon: '<span class="ui-icon ui-icon-circle-close"></span>',
       checkAllIcon: '<span class="ui-icon ui-icon-check"></span>',
       uncheckAllIcon: '<span class="ui-icon ui-icon-closethick"></span>',
       flipAllIcon: '<span class="ui-icon ui-icon-arrowrefresh-1-w"></span>',
-      checkAllText: 'Check all',																							// If blank or null, link not shown.
-      uncheckAllText: 'Uncheck all',																				// If blank or null, link not shown.
-      flipAllText: 'Flip all',																									// If blank or null, link not shown.
+      checkAllText: 'Check all',                                              // If blank or null, link not shown.
+      uncheckAllText: 'Uncheck all',                                          // If blank or null, link not shown.
+      flipAllText: 'Flip all',                                                // If blank or null, link not shown.
       showCheckAll: true,
       showUncheckAll: true,
       showFlipAll: false,
       noneSelectedText: 'Select options',
-      selectedText: '# of # selected',
+      selectedText: '# selected',
       selectedList: 0,
       show: null,
       hide: null,
@@ -56,7 +56,7 @@
 
     // This method determines which element to append the menu to
     // Uses the element provided in the options first, then looks for ui-front / dialog
-    // Otherwise appends to the body	 
+    // Otherwise appends to the body
     _getAppendEl: function() {
       var element = this.options.appendTo;
       if(element) {
@@ -98,18 +98,18 @@
           .html(o.noneSelectedText)
           .appendTo(button);
 
-	// This is the menu that will hold all the options
+         // This is the menu that will hold all the options
         this.menu = $('<div />')
           .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all ' + o.classes)
           .appendTo(this._getAppendEl());
 
-	// Menu header to hold controls for the menu
+         // Menu header to hold controls for the menu
         this.header = $('<div />')
           .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')
           .appendTo(this.menu);
 
-	// Header controls, will contain the check all/uncheck all buttons
-	// Depending on how the options are set, this may be empty or simply plain text
+         // Header controls, will contain the check all/uncheck all buttons
+         // Depending on how the options are set, this may be empty or simply plain text
         this.headerLinkContainer = $('<ul />')
           .addClass('ui-helper-reset')
           .html(function() {
@@ -134,7 +134,7 @@
           .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close" title="Close">' + o.closeIcon + '</a></li>')
           .appendTo(this.header);
 
-	// Holds the actual check boxes for inputs
+         // Holds the actual check boxes for inputs
         var checkboxContainer = (this.checkboxContainer = $('<ul />'))
           .addClass('ui-multiselect-checkboxes ui-helper-reset')
           .appendTo(this.menu);
@@ -152,15 +152,15 @@
         el.hide();
     },
 
-     // https://api.jqueryui.com/jquery.widget/#method-_init
+    // https://api.jqueryui.com/jquery.widget/#method-_init
     _init: function() {
       if(this.options.header === false) {
         this.header.hide();
       }
       if(!!this.element[0].multiple) {
-	this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
+        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
       } else {
-	this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
+        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
       }
       if(this.options.autoOpen) {
         this.open();
@@ -183,14 +183,14 @@
       var title = option.title ? option.title : null;
       var value = option.value;
       var el = this.element;
-      var id = el.attr('id') || this.multiselectID; 	// unique ID for the label & option tags
+      var id = el.attr('id') || this.multiselectID;   // unique ID for the label & option tags
       var inputID = 'ui-multiselect-' + this.multiselectID + '-' + (option.id || id + '-option-' + this.inputIdCounter++);
       var isDisabled = option.disabled;
       var isSelected = option.selected;
       var labelClasses = [ 'ui-corner-all' ];
       var liClasses = [];
       var o = this.options;
-      var isMultiple = !!el[0].multiple;   	// Pick up the select type from the underlying element 
+      var isMultiple = !!el[0].multiple;        // Pick up the select type from the underlying element
 
       if(isDisabled) {
         liClasses.push('ui-multiselect-disabled');
@@ -313,6 +313,7 @@
       if(isDefault) {
         this.button[0].defaultValue = value;
       }
+
     },
 
     // this exists as a separate method so that the developer
@@ -430,15 +431,15 @@
             self._traverse(e.which, this);
             break;
           case 13: // enter
-          case 32:
+          case 32: // space
             $(this).find('input')[0].click();
             break;
-          case 65:
+          case 65: // Ctrl-A
             if(e.altKey) {
               self.checkAll();
             }
             break;
-          case 85:
+          case 85: // Ctrl-U
             if(e.altKey) {
               self.uncheckAll();
             }
@@ -451,7 +452,7 @@
         var optionText = $this.parent().find("span").text();
         var checked = this.checked;
         var tags = self.element.find('option');
-		  var isMultiple = !!self.element[0].multiple;
+        var isMultiple = !!self.element[0].multiple;
 
         // bail if this input is disabled or the event is cancelled
         if(this.disabled || self._trigger('click', e, { value: val, text: optionText, checked: checked }) === false) {
@@ -556,7 +557,7 @@
     },
 
     // Determines the minimum width for the button and menu
-    // Can be a number, a digit string, or a percentage	 
+    // Can be a number, a digit string, or a percentage
     _getMinWidth: function() {
       var minVal = this.options.minWidth;
       var width = 0;
@@ -576,7 +577,7 @@
       }
       return width;
     },
-	 
+
     // set button width
     _setButtonWidth: function() {
       var width = this.element.outerWidth();
@@ -615,7 +616,7 @@
       this.menu.height(ulHeight + headerHeight);
     },
 
-    // Resizes the menu, called every time the menu is opened
+     // Resizes the menu, called every time the menu is opened
     _resizeMenu: function() {
       this._setMenuWidth();
       this._setMenuHeight();
@@ -654,12 +655,12 @@
     // The context of this function should be a checkbox; do not proxy it.
     _toggleState: function(prop, flag) {
       return function() {
-        var state = (flag === '!') ? !this[prop] : flag;
-			
-	if( !this.disabled ) {
+         var state = (flag === '!') ? !this[prop] : flag;
+
+         if( !this.disabled ) {
           this[ prop ] = state;
-        }        
-        
+        }
+
         if(state) {
           this.setAttribute('aria-' + prop, true);
         } else {
@@ -704,7 +705,7 @@
       }
     },
 
-    // Toggle disable state on the widget and underlying select
+      // Toggle disable state on the widget and underlying select
     _toggleDisabled: function(flag) {
       this.button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
 
@@ -842,15 +843,15 @@
     uncheckAll: function() {
       this._toggleChecked(false);
       if ( !this.element[0].multiple )
-        this.element[0].selectedIndex = -1;			// Forces the underlying single-select to have no options selected.
+         this.element[0].selectedIndex = -1;       // Forces the underlying single-select to have no options selected.
       this._trigger('uncheckAll');
     },
-	 
+
     flipAll: function() {
       this._toggleChecked('!');
       this._trigger('flipAll');
     },
-	  
+
     getChecked: function() {
       return this.menu.find('input').filter(':checked');
     },
@@ -894,7 +895,7 @@
       return this.labels;
     },
 
-    /*
+     /*
     * Adds an option to the widget and underlying select
     * attributes: Attributes hash to add to the option
     * text: text of the option
@@ -971,23 +972,23 @@
           menu.find('a.ui-multiselect-none span').eq(-1).text(value);
           break;
         case 'flipAllText':
-		    menu.find('a.ui-multiselect-flip span').eq(-1).text(value);
-  			 break;        			 
+          menu.find('a.ui-multiselect-flip span').eq(-1).text(value);
+          break;
         case 'checkAllIcon':
-          menu.find('a.ui-multiselect-all span').eq(0).replaceWith(value); 
+          menu.find('a.ui-multiselect-all span').eq(0).replaceWith(value);
           break;
         case 'uncheckAllIcon':
           menu.find('a.ui-multiselect-none span').eq(0).replaceWith(value);
           break;
         case 'flipAllIcon':
-		    menu.find('a.ui-multiselect-flip span').eq(0).replaceWith(value);
-  			 break;        			 
+          menu.find('a.ui-multiselect-flip span').eq(0).replaceWith(value);
+          break;
         case 'openIcon':
-		    menu.find('span.ui-multiselect-open').html(value);
-  			 break;        			 
+          menu.find('span.ui-multiselect-open').html(value);
+          break;
         case 'closeIcon':
-		    menu.find('a.ui-multiselect-close').html(value);
-  			 break;        			 
+          menu.find('a.ui-multiselect-close').html(value);
+          break;
         case 'height':
           this.options[key] = value;
           this._setMenuHeight();
@@ -1008,13 +1009,13 @@
           menu.add(this.button).removeClass(this.options.classes).addClass(value);
           break;
         case 'multiple':
-	  var el_0 = this.element[0];
-	  if (!!el_0.multiple != value) {
-	     menu.toggleClass('ui-multiselect-multiple', value);
-	     menu.toggleClass('ui-multiselect-single', !value);
-	     el_0.multiple = value;
-	     this.uncheckAll();
-	     this.refresh();
+          var el_0 = this.element[0];
+          if (!!el_0.multiple != value) {
+             menu.toggleClass('ui-multiselect-multiple', value);
+             menu.toggleClass('ui-multiselect-single', !value);
+             el_0.multiple = value;
+             this.uncheckAll();
+             this.refresh();
           }
           break;
         case 'position':

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -48,6 +48,10 @@
       groupColumns: false
     },
 
+
+    // This method determines which element to append the menu to
+    // Uses the element provided in the options first, then looks for ui-front / dialog
+    // Otherwise appends to the body	 
     _getAppendEl: function() {
       var element = this.options.appendTo;
       if(element) {
@@ -62,6 +66,7 @@
       return element;
     },
 
+	 // Performs the initial creation of the widget
     _create: function() {
       var el = this.element;
       var o = this.options;
@@ -77,6 +82,7 @@
       // bump unique ID after assigning it to the widget instance
       this.multiselectID = multiselectID++;
 
+		// The button that opens the widget menu
       var button = (this.button = $('<button type="button"><span class="ui-icon ui-icon-triangle-1-s"></span></button>'))
         .addClass('ui-multiselect ui-widget ui-state-default ui-corner-all ' + o.classes)
         .attr({ 'title':el.attr('title'), 'tabIndex':el.attr('tabIndex'), 'id': el.attr('id') ? el.attr('id')  + '_ms' : null })
@@ -87,14 +93,18 @@
           .html(o.noneSelectedText)
           .appendTo(button);
 
+			// This is the menu that will hold all the options
         this.menu = $('<div />')
           .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all ' + o.classes)
           .appendTo(this._getAppendEl());
 
+			// Menu header to hold controls for the menu
         this.header = $('<div />')
           .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')
           .appendTo(this.menu);
 
+	 		// Header controls, will contain the check all/uncheck all buttons
+      // Depending on how the options are set, this may be empty or simply plain text
         this.headerLinkContainer = $('<ul />')
           .addClass('ui-helper-reset')
           .html(function() {
@@ -116,6 +126,7 @@
           .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon '+o.closeIcon+'"></span></a></li>')
           .appendTo(this.header);
 
+		   // Holds the actual check boxes for inputs
         var checkboxContainer = (this.checkboxContainer = $('<ul />'))
           .addClass('ui-multiselect-checkboxes ui-helper-reset')
           .appendTo(this.menu);
@@ -126,13 +137,14 @@
         // build menu
         this.refresh(true);
 
-        // some addl. logic for single selects
+        // If this is a single select widget, add the appropriate class
         if(!el[0].multiple) {
           this.menu.addClass('ui-multiselect-single');
         }
         el.hide();
     },
 
+	 // https://api.jqueryui.com/jquery.widget/#method-_init
     _init: function() {
       if(this.options.header === false) {
         this.header.hide();
@@ -200,6 +212,8 @@
       return $item;
     },
 
+	 // Builds a menu item for each option in the underlying select
+   // Option groups are built here as well
     _buildOptionList: function(element, $appendTo) {
       var self = this;
       element.children().each(function() {
@@ -218,6 +232,8 @@
 
     },
 
+	 // Refreshes the widget to pick up changes to the underlying select
+   // Rebuilds the menu, sets button width
     refresh: function(init) {
       var self = this;
       var el = this.element;
@@ -242,7 +258,7 @@
       this.menu.find(".ui-multiselect-checkboxes").remove();
       this.menu.append($dropdown);
 
-      // cache some moar useful elements
+      // cache some more useful elements
       this.labels = menu.find('label');
       this.inputs = this.labels.children('input');
 
@@ -520,6 +536,9 @@
         setTimeout($.proxy(self.refresh, self), 10);
       });
     },
+
+    // Determines the minimum width for the button and menu
+    // Can be a number, a digit string, or a percentage	 
     _getMinWidth: function() {
       var minVal = this.options.minWidth;
       var width = 0;
@@ -539,6 +558,7 @@
       }
       return width;
     },
+	 
     // set button width
     _setButtonWidth: function() {
       var width = this.element.outerWidth();
@@ -558,6 +578,8 @@
       m.outerWidth(this.options.menuWidth || width);
     },
 
+	 // Sets the height of the menu
+   // Will set a scroll bar if the menu height exceeds that of the height in options
     _setMenuHeight: function() {
       var headerHeight = this.menu.children(".ui-multiselect-header:visible").outerHeight(true);
       var ulHeight = 0;
@@ -575,6 +597,7 @@
       this.menu.height(ulHeight + headerHeight);
     },
 
+	  // Resizes the menu, called every time the menu is opened
     _resizeMenu: function() {
       this._setMenuWidth();
       this._setMenuHeight();
@@ -625,6 +648,7 @@
       };
     },
 
+	 // Toggles checked state on either an option group or all inputs
     _toggleChecked: function(flag, group) {
       var $inputs = (group && group.length) ?  group : this.inputs;
       var self = this;
@@ -660,6 +684,7 @@
       }
     },
 
+	   // Toggle disable state on the widget and underlying select
     _toggleDisabled: function(flag) {
       this.button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
 
@@ -844,6 +869,12 @@
       return this.labels;
     },
 
+	  /*
+    * Adds an option to the widget and underlying select
+    * attributes: Attributes hash to add to the option
+    * text: text of the option
+    * groupLabel: Option Group to add the option to
+    */
     addOption: function(attributes, text, groupLabel) {
       var $option = $("<option/>").attr(attributes).text(text);
       var optionNode = $option.get(0);

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -40,7 +40,6 @@
       show: null,
       hide: null,
       autoOpen: false,
-      multiple: true,
       position: {},
       appendTo: null,
       menuWidth:null,
@@ -49,9 +48,6 @@
       groupColumns: false
     },
 
-    // This method determines which element to append the menu to
-    // Uses the element provided in the options first, then looks for ui-front / dialog
-    // Otherwise appends to the body
     _getAppendEl: function() {
       var element = this.options.appendTo;
       if(element) {
@@ -66,14 +62,13 @@
       return element;
     },
 
-    // Performs the initial creation of the widget
     _create: function() {
       var el = this.element;
       var o = this.options;
 
       this.speed = $.fx.speeds._default; // default speed for effects
       this._isOpen = false; // assume no
-      this.inputIdCounter = 0; // Incremented for each input item (option)
+      this.inputIdCounter = 0;
 
       // create a unique namespace for events that the widget
       // factory cannot unbind automatically. Use eventNamespace if on
@@ -82,77 +77,71 @@
       // bump unique ID after assigning it to the widget instance
       this.multiselectID = multiselectID++;
 
-      // The button that opens the widget menu
       var button = (this.button = $('<button type="button"><span class="ui-icon ui-icon-triangle-1-s"></span></button>'))
         .addClass('ui-multiselect ui-widget ui-state-default ui-corner-all ' + o.classes)
         .attr({ 'title':el.attr('title'), 'tabIndex':el.attr('tabIndex'), 'id': el.attr('id') ? el.attr('id')  + '_ms' : null })
         .prop('aria-haspopup', true)
         .insertAfter(el);
 
-      this.buttonlabel = $('<span />')
-        .html(o.noneSelectedText)
-        .appendTo(button);
+        this.buttonlabel = $('<span />')
+          .html(o.noneSelectedText)
+          .appendTo(button);
 
-      // This is the menu that will hold all the options
-      this.menu = $('<div />')
-        .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all ' + o.classes)
-        .appendTo(this._getAppendEl());
+        this.menu = $('<div />')
+          .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all ' + o.classes)
+          .appendTo(this._getAppendEl());
 
-      // Menu header to hold controls for the menu
-      this.header = $('<div />')
-        .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')
-        .appendTo(this.menu);
+        this.header = $('<div />')
+          .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')
+          .appendTo(this.menu);
 
-      // Header controls, will contain the check all/uncheck all buttons
-      // Depending on how the options are set, this may be empty or simply plain text
-      this.headerLinkContainer = $('<ul />')
-        .addClass('ui-helper-reset')
-        .html(function() {
-          if(o.header === true) {
-            var header_lis = '';
-            if(o.showCheckAll) {
-              header_lis = '<li><a class="ui-multiselect-all" href="#"><span class="ui-icon ui-icon-check"></span><span>' + o.checkAllText + '</span></a></li>';
+        this.headerLinkContainer = $('<ul />')
+          .addClass('ui-helper-reset')
+          .html(function() {
+            if(o.header === true) {
+              var header_lis = '';
+              if(o.showCheckAll) {
+                header_lis = '<li><a class="ui-multiselect-all" href="#"><span class="ui-icon ui-icon-check"></span><span>' + o.checkAllText + '</span></a></li>';
+              }
+              if(o.showUncheckAll) {
+                header_lis += '<li><a class="ui-multiselect-none" href="#"><span class="ui-icon ui-icon-closethick"></span><span>' + o.uncheckAllText + '</span></a></li>';
+              }
+              return header_lis;
+            } else if(typeof o.header === "string") {
+              return '<li>' + o.header + '</li>';
+            } else {
+              return '';
             }
-            if(o.showUncheckAll) {
-              header_lis += '<li><a class="ui-multiselect-none" href="#"><span class="ui-icon ui-icon-closethick"></span><span>' + o.uncheckAllText + '</span></a></li>';
-            }
-            return header_lis;
-          } else if(typeof o.header === "string") {
-            return '<li>' + o.header + '</li>';
-          } else {
-            return '';
-          }
-        })
-        .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon '+o.closeIcon+'"></span></a></li>')
-        .appendTo(this.header);
+          })
+          .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon '+o.closeIcon+'"></span></a></li>')
+          .appendTo(this.header);
 
-      // Holds the actual check boxes for inputs
-      var checkboxContainer = (this.checkboxContainer = $('<ul />'))
-        .addClass('ui-multiselect-checkboxes ui-helper-reset')
-        .appendTo(this.menu);
+        var checkboxContainer = (this.checkboxContainer = $('<ul />'))
+          .addClass('ui-multiselect-checkboxes ui-helper-reset')
+          .appendTo(this.menu);
 
-      this._bindEvents();
+        // perform event bindings
+        this._bindEvents();
 
-      // build menu
-      this.refresh(true);
+        // build menu
+        this.refresh(true);
 
-      // If this is a single select widget, add the appropriate class
-      if(!o.multiple) {
-        this.menu.addClass('ui-multiselect-single');
-      }
-      el.hide();
+        // some addl. logic for single selects
+        if(!el[0].multiple) {
+          this.menu.addClass('ui-multiselect-single');
+        }
+        el.hide();
     },
 
-    // https://api.jqueryui.com/jquery.widget/#method-_init
     _init: function() {
       if(this.options.header === false) {
         this.header.hide();
       }
-      if(!this.options.multiple) {
-        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
-      } else {
-        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
-      }
+	   if(!!this.element[0].multiple) {
+		  this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
+	   } else {
+		  this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
+	   }
       if(this.options.autoOpen) {
         this.open();
       }
@@ -161,25 +150,18 @@
       }
     },
 
-    /*
-    * Builds an option item for the menu
-    * <li>
-    *   <label>
-    *     <input /> checkbox or radio depending on single/multiple select
-    *     <span /> option text
-    *   </label>
-    * </li>
-    */
     _makeOption: function(option) {
       var title = option.title ? option.title : null;
       var value = option.value;
-      var id = this.element.attr('id') || this.multiselectID; // unique ID for the label & option tags
+		var el = this.element;
+      var id = el.attr('id') || this.multiselectID; 	// unique ID for the label & option tags
       var inputID = 'ui-multiselect-' + this.multiselectID + '-' + (option.id || id + '-option-' + this.inputIdCounter++);
       var isDisabled = option.disabled;
       var isSelected = option.selected;
       var labelClasses = [ 'ui-corner-all' ];
       var liClasses = [];
       var o = this.options;
+		var isMultiple = !!el[0].multiple;   		// Pick up the select type from the underlying element 
 
       if(isDisabled) {
         liClasses.push('ui-multiselect-disabled');
@@ -188,7 +170,7 @@
       if(option.className) {
         liClasses.push(option.className);
       }
-      if(isSelected && !o.multiple) {
+      if(isSelected && !isMultiple) {
         labelClasses.push('ui-state-active');
       }
 
@@ -199,7 +181,7 @@
       }).addClass(labelClasses.join(' ')).appendTo($item);
       var $input = $("<input/>").attr({
         "name": "multiselect_" + id,
-        "type": o.multiple ? "checkbox" : "radio",
+        "type": isMultiple ? "checkbox" : "radio",
         "value": value,
         "title": title,
         "id": inputID,
@@ -217,8 +199,7 @@
 
       return $item;
     },
-    // Builds a menu item for each option in the underlying select
-    // Option groups are built here as well
+
     _buildOptionList: function(element, $appendTo) {
       var self = this;
       element.children().each(function() {
@@ -237,24 +218,22 @@
 
     },
 
-    // Refreshes the widget to pick up changes to the underlying select
-    // Rebuilds the menu, sets button width
     refresh: function(init) {
       var self = this;
       var el = this.element;
       var o = this.options;
       var menu = this.menu;
       var checkboxContainer = this.checkboxContainer;
+      var html = "";
       var $dropdown = $("<ul/>").addClass('ui-multiselect-checkboxes ui-helper-reset');
       this.inputIdCounter = 0;
 
-
       // update header link container visibility if needed
       if (this.options.header) {
-        if(!this.options.multiple) {
-          this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
-        } else {
+        if(!!el[0].multiple) {
           this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
+        } else {
+          this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
         }
       }
 
@@ -305,7 +284,7 @@
     },
 
     // this exists as a separate method so that the developer
-    // can easily override it, usually to allow injecting HTML if they really want it
+    // can easily override it.
     _setButtonValue: function(value) {
       this.buttonlabel.text(value);
     },
@@ -419,15 +398,15 @@
             self._traverse(e.which, this);
             break;
           case 13: // enter
-          case 32: //space
+          case 32:
             $(this).find('input')[0].click();
             break;
-          case 65: // a
+          case 65:
             if(e.altKey) {
               self.checkAll();
             }
             break;
-          case 85: // u
+          case 85:
             if(e.altKey) {
               self.uncheckAll();
             }
@@ -440,6 +419,7 @@
         var optionText = $this.parent().find("span").text();
         var checked = this.checked;
         var tags = self.element.find('option');
+		  var isMultiple = !!self.element[0].multiple;
 
         // bail if this input is disabled or the event is cancelled
         if(this.disabled || self._trigger('click', e, { value: val, text: optionText, checked: checked }) === false) {
@@ -458,13 +438,13 @@
         tags.each(function() {
           if(this.value === val) {
             this.selected = checked;
-          } else if(!self.options.multiple) {
+          } else if(!isMultiple) {
             this.selected = false;
           }
         });
 
         // some additional single select-specific logic
-        if(!self.options.multiple) {
+        if(!isMultiple) {
           self.labels.removeClass('ui-state-active');
           $this.closest('label').toggleClass('ui-state-active', checked);
 
@@ -496,10 +476,10 @@
         e.preventDefault();
       }).on('keydown.multiselect', 'a', function(e) {
         switch(e.which) {
-          case 27: // esc
+          case 27:
             self.close();
             break;
-          case 9: // tab
+          case 9:
             var $target = $(e.target);
             if((e.shiftKey && !$target.parent().prev().length && !self.header.find(".ui-multiselect-filter").length) || (!$target.parent().next().length && !self.labels.length && !e.shiftKey)) {
               self.close();
@@ -510,6 +490,7 @@
       });
     },
 
+    // binds events
     _bindEvents: function() {
       var self = this;
 
@@ -539,9 +520,6 @@
         setTimeout($.proxy(self.refresh, self), 10);
       });
     },
-
-    // Determines the minimum width for the button and menu
-    // Can be a number, a digit string, or a percentage
     _getMinWidth: function() {
       var minVal = this.options.minWidth;
       var width = 0;
@@ -580,8 +558,6 @@
       m.outerWidth(this.options.menuWidth || width);
     },
 
-    // Sets the height of the menu
-    // Will set a scroll bar if the menu height exceeds that of the height in options
     _setMenuHeight: function() {
       var headerHeight = this.menu.children(".ui-multiselect-header:visible").outerHeight(true);
       var ulHeight = 0;
@@ -599,7 +575,6 @@
       this.menu.height(ulHeight + headerHeight);
     },
 
-    // Resizes the menu, called every time the menu is opened
     _resizeMenu: function() {
       this._setMenuWidth();
       this._setMenuHeight();
@@ -650,7 +625,6 @@
       };
     },
 
-    // Toggles checked state on either an option group or all inputs
     _toggleChecked: function(flag, group) {
       var $inputs = (group && group.length) ?  group : this.inputs;
       var self = this;
@@ -658,8 +632,8 @@
       // toggle state on inputs
       $inputs.each(this._toggleState('checked', flag));
 
-      // give the first input focus
-      $inputs.eq(0).focus();
+      // Give the first input focus
+		$inputs.eq(0).focus();
 
       // update button text
       this.update();
@@ -671,6 +645,7 @@
       });
 
       // toggle state on original option tags
+		this.element.selectedIndex = -1;
       this.element
         .find('option')
         .each(function() {
@@ -685,7 +660,6 @@
       }
     },
 
-    // Toggle disable state on the widget and underlying select
     _toggleDisabled: function(flag) {
       this.button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
 
@@ -822,6 +796,8 @@
 
     uncheckAll: function() {
       this._toggleChecked(false);
+		if ( !this.element[0].multiple )
+			this.element[0].selectedIndex = -1;			// Forces the underlying single-select to have no options selected.
       this._trigger('uncheckAll');
     },
 
@@ -868,12 +844,6 @@
       return this.labels;
     },
 
-    /*
-    * Adds an option to the widget and underlying select
-    * attributes: Attributes hash to add to the option
-    * text: text of the option
-    * groupLabel: Option Group to add the option to
-    */
     addOption: function(attributes, text, groupLabel) {
       var $option = $("<option/>").attr(attributes).text(text);
       var optionNode = $option.get(0);
@@ -964,11 +934,14 @@
           menu.add(this.button).removeClass(this.options.classes).addClass(value);
           break;
         case 'multiple':
-          menu.toggleClass('ui-multiselect-single', !value);
-          this.options.multiple = value;
-          this.element[0].multiple = value;
-          this.uncheckAll();
-          this.refresh();
+		    var el_0 = this.element[0];
+			 if (!!el_0.multiple != value) {
+				 menu.toggleClass('ui-multiselect-multiple', value);
+				 menu.toggleClass('ui-multiselect-single', !value);
+				 el_0.multiple = value;
+				 this.uncheckAll();
+				 this.refresh();
+			 }
           break;
         case 'position':
           this.position();

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -29,14 +29,20 @@
       height: 175,
       minWidth: 225,
       classes: '',
-      checkAllText: 'Check all',
-      uncheckAllText: 'Uncheck all',
-      noneSelectedText: 'Select options',
+      openIcon: '<span class="ui-icon ui-icon-triangle-1-s"></span>',   // Scaleable HTML Entities or Font-Awesome icons can be used here instead of the default jQuery UI icons.
+      closeIcon: '<span class="ui-icon ui-icon-circle-close"></span>',
+      checkAllIcon: '<span class="ui-icon ui-icon-check"></span>',
+      uncheckAllIcon: '<span class="ui-icon ui-icon-closethick"></span>',
+      flipAllIcon: '<span class="ui-icon ui-icon-arrowrefresh-1-w"></span>',
+      checkAllText: 'Check all',																							// If blank or null, link not shown.
+      uncheckAllText: 'Uncheck all',																				// If blank or null, link not shown.
+      flipAllText: 'Flip all',																									// If blank or null, link not shown.
       showCheckAll: true,
       showUncheckAll: true,
-      selectedText: '# selected',
+      showFlipAll: false,
+      noneSelectedText: 'Select options',
+      selectedText: '# of # selected',
       selectedList: 0,
-      closeIcon: 'ui-icon-circle-close',
       show: null,
       hide: null,
       autoOpen: false,
@@ -47,7 +53,6 @@
       disableInputsOnToggle: true,
       groupColumns: false
     },
-
 
     // This method determines which element to append the menu to
     // Uses the element provided in the options first, then looks for ui-front / dialog
@@ -66,7 +71,7 @@
       return element;
     },
 
-	 // Performs the initial creation of the widget
+    // Performs the initial creation of the widget
     _create: function() {
       var el = this.element;
       var o = this.options;
@@ -82,8 +87,8 @@
       // bump unique ID after assigning it to the widget instance
       this.multiselectID = multiselectID++;
 
-		// The button that opens the widget menu
-      var button = (this.button = $('<button type="button"><span class="ui-icon ui-icon-triangle-1-s"></span></button>'))
+      // The button that opens the widget menu
+      var button = (this.button = $('<button type="button"><span class="ui-multiselect-open">' + o.openIcon + '</span></button>'))
         .addClass('ui-multiselect ui-widget ui-state-default ui-corner-all ' + o.classes)
         .attr({ 'title':el.attr('title'), 'tabIndex':el.attr('tabIndex'), 'id': el.attr('id') ? el.attr('id')  + '_ms' : null })
         .prop('aria-haspopup', true)
@@ -93,28 +98,31 @@
           .html(o.noneSelectedText)
           .appendTo(button);
 
-			// This is the menu that will hold all the options
+	// This is the menu that will hold all the options
         this.menu = $('<div />')
           .addClass('ui-multiselect-menu ui-widget ui-widget-content ui-corner-all ' + o.classes)
           .appendTo(this._getAppendEl());
 
-			// Menu header to hold controls for the menu
+	// Menu header to hold controls for the menu
         this.header = $('<div />')
           .addClass('ui-widget-header ui-corner-all ui-multiselect-header ui-helper-clearfix')
           .appendTo(this.menu);
 
-	 		// Header controls, will contain the check all/uncheck all buttons
-      // Depending on how the options are set, this may be empty or simply plain text
+	// Header controls, will contain the check all/uncheck all buttons
+	// Depending on how the options are set, this may be empty or simply plain text
         this.headerLinkContainer = $('<ul />')
           .addClass('ui-helper-reset')
           .html(function() {
             if(o.header === true) {
               var header_lis = '';
-              if(o.showCheckAll) {
-                header_lis = '<li><a class="ui-multiselect-all" href="#"><span class="ui-icon ui-icon-check"></span><span>' + o.checkAllText + '</span></a></li>';
+              if(o.showCheckAll && o.checkAllText) {
+                header_lis = '<li><a href="#" class="ui-multiselect-all" title="Check All">' + o.checkAllIcon + '<span>' + o.checkAllText + '</span></a></li>';
               }
-              if(o.showUncheckAll) {
-                header_lis += '<li><a class="ui-multiselect-none" href="#"><span class="ui-icon ui-icon-closethick"></span><span>' + o.uncheckAllText + '</span></a></li>';
+              if(o.showUncheckAll && o.uncheckAllText) {
+                header_lis += '<li><a href="#" class="ui-multiselect-none" title="Uncheck All">' + o.uncheckAllIcon + '<span>' + o.uncheckAllText + '</span></a></li>';
+              }
+              if(o.showFlipAll && o.flipAllText) {
+                header_lis += '<li><a href="#" class="ui-multiselect-flip" title="Flip All">' + o.flipAllIcon + '<span>' + o.flipAllText + '</span></a></li>';
               }
               return header_lis;
             } else if(typeof o.header === "string") {
@@ -123,10 +131,10 @@
               return '';
             }
           })
-          .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close"><span class="ui-icon '+o.closeIcon+'"></span></a></li>')
+          .append('<li class="ui-multiselect-close"><a href="#" class="ui-multiselect-close" title="Close">' + o.closeIcon + '</a></li>')
           .appendTo(this.header);
 
-		   // Holds the actual check boxes for inputs
+	// Holds the actual check boxes for inputs
         var checkboxContainer = (this.checkboxContainer = $('<ul />'))
           .addClass('ui-multiselect-checkboxes ui-helper-reset')
           .appendTo(this.menu);
@@ -144,16 +152,16 @@
         el.hide();
     },
 
-	 // https://api.jqueryui.com/jquery.widget/#method-_init
+     // https://api.jqueryui.com/jquery.widget/#method-_init
     _init: function() {
       if(this.options.header === false) {
         this.header.hide();
       }
-	   if(!!this.element[0].multiple) {
-		  this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
-	   } else {
-		  this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
-	   }
+      if(!!this.element[0].multiple) {
+	this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
+      } else {
+	this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
+      }
       if(this.options.autoOpen) {
         this.open();
       }
@@ -162,10 +170,19 @@
       }
     },
 
+    /*
+    * Builds an option item for the menu
+    * <li>
+    *   <label>
+    *     <input /> checkbox or radio depending on single/multiple select
+    *     <span /> option text
+    *   </label>
+    * </li>
+    */
     _makeOption: function(option) {
       var title = option.title ? option.title : null;
       var value = option.value;
-		var el = this.element;
+      var el = this.element;
       var id = el.attr('id') || this.multiselectID; 	// unique ID for the label & option tags
       var inputID = 'ui-multiselect-' + this.multiselectID + '-' + (option.id || id + '-option-' + this.inputIdCounter++);
       var isDisabled = option.disabled;
@@ -173,7 +190,7 @@
       var labelClasses = [ 'ui-corner-all' ];
       var liClasses = [];
       var o = this.options;
-		var isMultiple = !!el[0].multiple;   		// Pick up the select type from the underlying element 
+      var isMultiple = !!el[0].multiple;   	// Pick up the select type from the underlying element 
 
       if(isDisabled) {
         liClasses.push('ui-multiselect-disabled');
@@ -212,8 +229,8 @@
       return $item;
     },
 
-	 // Builds a menu item for each option in the underlying select
-   // Option groups are built here as well
+    // Builds a menu item for each option in the underlying select
+    // Option groups are built here as well
     _buildOptionList: function(element, $appendTo) {
       var self = this;
       element.children().each(function() {
@@ -232,8 +249,8 @@
 
     },
 
-	 // Refreshes the widget to pick up changes to the underlying select
-   // Rebuilds the menu, sets button width
+    // Refreshes the widget to pick up changes to the underlying select
+    // Rebuilds the menu, sets button width
     refresh: function(init) {
       var self = this;
       var el = this.element;
@@ -296,7 +313,6 @@
       if(isDefault) {
         this.button[0].defaultValue = value;
       }
-
     },
 
     // this exists as a separate method so that the developer
@@ -488,6 +504,8 @@
           self.checkAll();
         } else if($this.hasClass("ui-multiselect-none")) {
           self.uncheckAll();
+        } else if($this.hasClass("ui-multiselect-flip")) {
+          self.flipAll();
         }
         e.preventDefault();
       }).on('keydown.multiselect', 'a', function(e) {
@@ -578,8 +596,8 @@
       m.outerWidth(this.options.menuWidth || width);
     },
 
-	 // Sets the height of the menu
-   // Will set a scroll bar if the menu height exceeds that of the height in options
+    // Sets the height of the menu
+    // Will set a scroll bar if the menu height exceeds that of the height in options
     _setMenuHeight: function() {
       var headerHeight = this.menu.children(".ui-multiselect-header:visible").outerHeight(true);
       var ulHeight = 0;
@@ -597,7 +615,7 @@
       this.menu.height(ulHeight + headerHeight);
     },
 
-	  // Resizes the menu, called every time the menu is opened
+    // Resizes the menu, called every time the menu is opened
     _resizeMenu: function() {
       this._setMenuWidth();
       this._setMenuHeight();
@@ -636,19 +654,21 @@
     // The context of this function should be a checkbox; do not proxy it.
     _toggleState: function(prop, flag) {
       return function() {
-        if(!this.disabled) {
-          this[ prop ] = flag;
-        }
-
-        if(flag) {
-          this.setAttribute('aria-selected', true);
+        var state = (flag === '!') ? !this[prop] : flag;
+			
+	if( !this.disabled ) {
+          this[ prop ] = state;
+        }        
+        
+        if(state) {
+          this.setAttribute('aria-' + prop, true);
         } else {
-          this.removeAttribute('aria-selected');
+          this.removeAttribute('aria-' + prop);
         }
       };
     },
 
-	 // Toggles checked state on either an option group or all inputs
+    // Toggles checked state on either an option group or all inputs
     _toggleChecked: function(flag, group) {
       var $inputs = (group && group.length) ?  group : this.inputs;
       var self = this;
@@ -657,7 +677,7 @@
       $inputs.each(this._toggleState('checked', flag));
 
       // Give the first input focus
-		$inputs.eq(0).focus();
+      $inputs.eq(0).focus();
 
       // update button text
       this.update();
@@ -669,7 +689,7 @@
       });
 
       // toggle state on original option tags
-		this.element.selectedIndex = -1;
+      this.element.selectedIndex = -1;
       this.element
         .find('option')
         .each(function() {
@@ -684,7 +704,7 @@
       }
     },
 
-	   // Toggle disable state on the widget and underlying select
+    // Toggle disable state on the widget and underlying select
     _toggleDisabled: function(flag) {
       this.button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ]('ui-state-disabled');
 
@@ -821,11 +841,16 @@
 
     uncheckAll: function() {
       this._toggleChecked(false);
-		if ( !this.element[0].multiple )
-			this.element[0].selectedIndex = -1;			// Forces the underlying single-select to have no options selected.
+      if ( !this.element[0].multiple )
+        this.element[0].selectedIndex = -1;			// Forces the underlying single-select to have no options selected.
       this._trigger('uncheckAll');
     },
-
+	 
+    flipAll: function() {
+      this._toggleChecked('!');
+      this._trigger('flipAll');
+    },
+	  
     getChecked: function() {
       return this.menu.find('input').filter(':checked');
     },
@@ -869,7 +894,7 @@
       return this.labels;
     },
 
-	  /*
+    /*
     * Adds an option to the widget and underlying select
     * attributes: Attributes hash to add to the option
     * text: text of the option
@@ -940,11 +965,29 @@
           }
           break;
         case 'checkAllText':
-          menu.find('a.ui-multiselect-all span').eq(-1).text(value);
+          menu.find('a.ui-multiselect-all span').eq(-1).text(value);     // eq(-1) finds the last span
           break;
         case 'uncheckAllText':
           menu.find('a.ui-multiselect-none span').eq(-1).text(value);
           break;
+        case 'flipAllText':
+		    menu.find('a.ui-multiselect-flip span').eq(-1).text(value);
+  			 break;        			 
+        case 'checkAllIcon':
+          menu.find('a.ui-multiselect-all span').eq(0).replaceWith(value); 
+          break;
+        case 'uncheckAllIcon':
+          menu.find('a.ui-multiselect-none span').eq(0).replaceWith(value);
+          break;
+        case 'flipAllIcon':
+		    menu.find('a.ui-multiselect-flip span').eq(0).replaceWith(value);
+  			 break;        			 
+        case 'openIcon':
+		    menu.find('span.ui-multiselect-open').html(value);
+  			 break;        			 
+        case 'closeIcon':
+		    menu.find('a.ui-multiselect-close').html(value);
+  			 break;        			 
         case 'height':
           this.options[key] = value;
           this._setMenuHeight();
@@ -965,14 +1008,14 @@
           menu.add(this.button).removeClass(this.options.classes).addClass(value);
           break;
         case 'multiple':
-		    var el_0 = this.element[0];
-			 if (!!el_0.multiple != value) {
-				 menu.toggleClass('ui-multiselect-multiple', value);
-				 menu.toggleClass('ui-multiselect-single', !value);
-				 el_0.multiple = value;
-				 this.uncheckAll();
-				 this.refresh();
-			 }
+	  var el_0 = this.element[0];
+	  if (!!el_0.multiple != value) {
+	     menu.toggleClass('ui-multiselect-multiple', value);
+	     menu.toggleClass('ui-multiselect-single', !value);
+	     el_0.multiple = value;
+	     this.uncheckAll();
+	     this.refresh();
+          }
           break;
         case 'position':
           this.position();

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -158,9 +158,9 @@
         this.header.hide();
       }
       if(!!this.element[0].multiple) {
-        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
+        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none, .ui-multiselect-flip').show();
       } else {
-        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
+        this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none, .ui-multiselect-flip').hide();
       }
       if(this.options.autoOpen) {
         this.open();
@@ -264,9 +264,9 @@
       // update header link container visibility if needed
       if (this.options.header) {
         if(!!el[0].multiple) {
-          this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').show();
+          this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none, .ui-multiselect-flip').show();
         } else {
-          this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none').hide();
+          this.headerLinkContainer.find('.ui-multiselect-all, .ui-multiselect-none, .ui-multiselect-flip').hide();
         }
       }
 

--- a/tests/unit/core.js
+++ b/tests/unit/core.js
@@ -109,9 +109,10 @@ QUnit.done = function(){
 		var form = $('<form></form>').appendTo("body"),
 			radios, data;
 		
-		el = $('<select id="test" name="test" multiple="multiple"><option value="foo">foo</option><option value="bar">bar</option><option value="baz">baz</option></select>')
+		// Use an underlying single-select here.
+		el = $('<select id="test" name="test"><option value="foo">foo</option><option value="bar">bar</option><option value="baz">baz</option></select>')
 			.appendTo(form)
-			.multiselect({ multiple: false });
+			.multiselect();
 		
 		// select multiple radios to ensure that, in the underlying select, only one
 		// will remain selected
@@ -139,7 +140,7 @@ QUnit.done = function(){
 		// expose original
 		el.multiselect("destroy");
 		data = form.serialize();
-		equals( data, 'test=foo&test=bar&test=baz', 'after destroying the widget and serializing the form, the correct key was serialized: ' + data);
+		equals( data, 'test=baz', 'after destroying the widget and serializing the form, the correct key was serialized: ' + data);
 		
 		form.remove();
 	});

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -242,6 +242,7 @@
 	test("multiple (false - single select)", function(){
 		expect(10);
 
+		$("select").removeAttr("multiple");
 		el = $("select").multiselect({ multiple:false });
 
 		// get some references
@@ -274,6 +275,7 @@
 		equals( $menu.find(".ui-multiselect-all, ui-multiselect-none").filter(":visible").length, 0, "Check/uncheck all links don't exist");
 
 		el.multiselect("destroy");
+		$("select").attr("multiple","multiple");
 	});
 
 	test("multiple (changing dynamically)", function(){

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -198,7 +198,7 @@
 		expect(2);
 		var text = "foo";
 
-		el = $("select").multiselect({ checkAllText:text });
+		el = $("select").multiselect({ checkAllText:text, showCheckAll:true });
 		equals( text, menu().find(".ui-multiselect-all").text(), 'check all link reads '+text );
 
 		// set through option
@@ -213,7 +213,7 @@
 		expect(2);
 		var text = "foo";
 
-		el = $("select").multiselect({ uncheckAllText:text });
+		el = $("select").multiselect({ uncheckAllText:text, showUncheckAll:true });
 		equals( text, menu().find(".ui-multiselect-none").text(), 'check all link reads '+text );
 
 		// set through option
@@ -224,6 +224,21 @@
 		el.multiselect("destroy");
 	});
 
+	test("flipAllText", function(){
+		expect(2);
+		var text = "foo";
+
+		el = $("select").multiselect({ flipAllText:text, showFlipAll:true });
+		equals( text, menu().find(".ui-multiselect-flip").text(), 'flip all link reads '+text );
+
+		// set through option
+		text = "bar";
+		el.multiselect("option","flipAllText","bar");
+		equals( text, menu().find(".ui-multiselect-flip").text(), 'changing value through api to '+text );
+
+		el.multiselect("destroy");
+	});
+	
 	test("autoOpen", function(){
 		expect(2);
 
@@ -352,11 +367,18 @@
 
 		el.multiselect("destroy");
 	});
+	test("openIcon", function(){
+		expect(1);
+		var icon = '<span class="ui-icon ui-icon-search"></span>';   
+		el = $("select").multiselect({ openIcon:icon });
+		equals(button().find(".ui-multiselect-open").find(".ui-icon-search").length, 1);
+		el.multiselect("destroy");
+	});
 	test("closeIcon", function(){
 		expect(1);
-		var icon = "ui-icon-search";
+		var icon = '<span class="ui-icon ui-icon-search"></span>';   
 		el = $("select").multiselect({ autoOpen:true, closeIcon:icon });
-		equals(menu().find(".ui-multiselect-close").find("."+icon).length, 1);
+		equals(menu().find(".ui-multiselect-close").find(".ui-icon-search").length, 1);
 		el.multiselect("destroy");
 	});
     test("selectedListSeparator", function(){


### PR DESCRIPTION
_(This is a re-do of #719 on the new version3 branch.)_

* Update jquery.multiselect.js

Eliminate the need for the multiple option by instead relying on the multiple attribute of the underlying native select element.

* Update core.js
* Update options.js

Update tests due to elimination of using multiple option in favor of using multiple attribute of underlying native select.
  