### PR TITLE
Filter Code Refactor & Fix Scroll on Focus Issues

### DIFF
--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -15,7 +15,7 @@
  */
 (function($) {
   var rEscape = /[\-\[\]{}()*+?.,\\\^$|#\s]/g;
-  
+
   // "{{term}}" is a placeholder below for where the search term
   // would be inserted in the resulting regular expression.
   var filterRules = {
@@ -58,13 +58,13 @@
   $.widget('ech.multiselectfilter', {
 
     options: {
-      label: 'Filter:',              // (string) The label to show with the input
-      placeholder: 'Enter keywords', // (string) The placeholder text to show in the input
-      filterRule: 'contains',        // (string) Either a named filter rule from above or a regular expression containing {{term}} as a placeholder
-      searchGroups: false,           // (true | false) If true, search option group labels and show an entire group on a match.
-      autoReset: false,              // (true | false) If true, clear the filter each time the widget menu is closed.
-      width: null,                   // (number) Override default width set in css file (px). null will inherit
-      debounceMS: 250                // (number) Number of milleseconds to wait between running the search handler.
+      label: 'Filter:',                // (string) The label to show with the input
+      placeholder: 'Enter keywords',   // (string) The placeholder text to show in the input
+      filterRule: 'contains',          // (string) Either a named filter rule from above or a regular expression containing {{term}} as a placeholder
+      searchGroups: false,             // (true | false) If true, search option group labels and show an entire group on a match.
+      autoReset: false,                // (true | false) If true, clear the filter each time the widget menu is closed.
+      width: null,                     // (number) Override default width set in css file (px). null will inherit
+      debounceMS: 250                  // (number) Number of milleseconds to wait between running the search handler.
     },
 
    /**

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -85,17 +85,17 @@
       position: {},                       // (object) A jQuery UI position object that constrains how the pop-up menu is positioned.
       zIndex: null,                       // (integer) Overrides the z-index set for the menu container.
       classes: '',                        // (string) Classes that you can provide to be applied to the elements making up the widget.
-      header: ['checkAll','uncheckAll'],      // (false | string | array) False, custom string or array indicating which links to show in the header & in what order.
+      header: ['checkAll','uncheckAll'],  // (false | string | array) False, custom string or array indicating which links to show in the header & in what order.
       linkInfo: null,                     // (object | null) Supply an obect of link information to use alternative icons, icon labels, or icon title text.  See linkDefaults above for object structure.
       noneSelectedText: 'Select options', // (string | null) The text to show in the button where nothing is selected.  Set to null to use the native select's placeholder text.
       selectedText: '# of # selected',    // (string) A "template" that indicates how to show the count of selections in the button.  The "#'s" are replaced by the selection count & option count.
       selectedList: 0,                    // (integer) The actual list selections will be shown in the button when the count of selections is <= than this number.
       selectedListSeparator: ', ',        // (string) This allows customization of the list separator.  Use ',<br/>' to make the button grow vertically showing 1 selection per line.
       maxSelected: null,                  // (integer | null)  If selected count > maxSelected, then message is displayed, and new selection is undone.
-      openEffect: null,                         // (array) An array containing menu opening effect information.
-      closeEffect: null,                         // (array) An array containing menu closing effect information.
+      openEffect: null,                   // (array) An array containing menu opening effect information.
+      closeEffect: null,                  // (array) An array containing menu closing effect information.
       autoOpen: false,                    // (true | false) If true, then the menu will be opening immediately after initialization.
-      htmlText: [],                                      // (array) List of 'button' &/or 'options' indicating in which parts of the widget to treat text as html.
+      htmlText: [],                       // (array) List of 'button' &/or 'options' indicating in which parts of the widget to treat text as html.
       wrapText: ['button','header','options'],  // (array) List of 'button', 'header', &/or 'options' indicating in which parts of the widget to wrap text.
       listbox: false,                     // (true | false) Omits the button and instead of a pop-up inserts the open menu directly after the native select as a list box.
       addInputNames: true,                // (true | false) If true, names are created for each option input in the multi-select.

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -731,8 +731,19 @@
       // option label
       .on('mouseenter.multiselect', 'label', function() {
         if (!this.classList.contains('ui-state-disabled')) {
+			 var checkboxes = self.$checkboxes[0];
+			 var scrollLeft = checkboxes.scrollLeft;
+			 var scrollTop = checkboxes.scrollTop;
+			 var scrollX = window.scrollX;
+			 var scrollY = window.scrollY;
+			 
           self.$labels.removeClass('ui-state-hover');
           $(this).addClass('ui-state-hover').find('input').focus();
+			 
+			 // Restore scroll positions if altered by setting input focus
+			 checkboxes.scrollLeft = scrollLeft;
+			 checkboxes.scrollTop = scrollTop;
+			 window.scrollTo(scrollX, scrollY);
         }
       })
       // Keyboard navigation of the menu
@@ -1363,6 +1374,8 @@
       var speed = this.speed;
       var options = this.options;
       var effect = options.openEffect;
+		var scrollX = window.scrollX;
+		var scrollY = window.scrollY;       
 
       // figure out opening effects/speeds
       if (effect && effect.constructor == Array) {
@@ -1400,6 +1413,9 @@
       else {
         $header.find('a').first().trigger('focus');
       }
+       
+		// Restore window scroll position if altered by setting element focus
+		window.scrollTo(scrollX, scrollY);
 
       $button.addClass('ui-state-active');
       this._isOpen = true;

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1691,7 +1691,7 @@
      * @returns {array} List of option groups that are collapsed
      */
     getCollapsed: function() {
-       return this.$checkboxes.find('.ui-multiselect-optgroup');
+       return this.$checkboxes.find('.ui-multiselect-collapsed');
     },
 
     /**

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -85,17 +85,17 @@
       position: {},                       // (object) A jQuery UI position object that constrains how the pop-up menu is positioned.
       zIndex: null,                       // (integer) Overrides the z-index set for the menu container.
       classes: '',                        // (string) Classes that you can provide to be applied to the elements making up the widget.
-      header: ['checkAll','uncheckAll'],  // (false | string | array) False, custom string or array indicating which links to show in the header & in what order.
+      header: ['checkAll','uncheckAll'],      // (false | string | array) False, custom string or array indicating which links to show in the header & in what order.
       linkInfo: null,                     // (object | null) Supply an obect of link information to use alternative icons, icon labels, or icon title text.  See linkDefaults above for object structure.
       noneSelectedText: 'Select options', // (string | null) The text to show in the button where nothing is selected.  Set to null to use the native select's placeholder text.
       selectedText: '# of # selected',    // (string) A "template" that indicates how to show the count of selections in the button.  The "#'s" are replaced by the selection count & option count.
       selectedList: 0,                    // (integer) The actual list selections will be shown in the button when the count of selections is <= than this number.
       selectedListSeparator: ', ',        // (string) This allows customization of the list separator.  Use ',<br/>' to make the button grow vertically showing 1 selection per line.
       maxSelected: null,                  // (integer | null)  If selected count > maxSelected, then message is displayed, and new selection is undone.
-      openEffect: null,                   // (array) An array containing menu opening effect information.
-      closeEffect: null,                  // (array) An array containing menu closing effect information.
+      openEffect: null,                         // (array) An array containing menu opening effect information.
+      closeEffect: null,                         // (array) An array containing menu closing effect information.
       autoOpen: false,                    // (true | false) If true, then the menu will be opening immediately after initialization.
-      htmlText: [],                       // (array) List of 'button' &/or 'options' indicating in which parts of the widget to treat text as html.
+      htmlText: [],                                      // (array) List of 'button' &/or 'options' indicating in which parts of the widget to treat text as html.
       wrapText: ['button','header','options'],  // (array) List of 'button', 'header', &/or 'options' indicating in which parts of the widget to wrap text.
       listbox: false,                     // (true | false) Omits the button and instead of a pop-up inserts the open menu directly after the native select as a list box.
       addInputNames: true,                // (true | false) If true, names are created for each option input in the multi-select.
@@ -731,19 +731,19 @@
       // option label
       .on('mouseenter.multiselect', 'label', function() {
         if (!this.classList.contains('ui-state-disabled')) {
-			 var checkboxes = self.$checkboxes[0];
-			 var scrollLeft = checkboxes.scrollLeft;
-			 var scrollTop = checkboxes.scrollTop;
-			 var scrollX = window.scrollX;
-			 var scrollY = window.scrollY;
-			 
+          var checkboxes = self.$checkboxes[0];
+          var scrollLeft = checkboxes.scrollLeft;
+          var scrollTop = checkboxes.scrollTop;
+          var scrollX = window.scrollX;
+          var scrollY = window.scrollY;
+
           self.$labels.removeClass('ui-state-hover');
           $(this).addClass('ui-state-hover').find('input').focus();
-			 
-			 // Restore scroll positions if altered by setting input focus
-			 checkboxes.scrollLeft = scrollLeft;
-			 checkboxes.scrollTop = scrollTop;
-			 window.scrollTo(scrollX, scrollY);
+
+          // Restore scroll positions if altered by setting input focus
+          checkboxes.scrollLeft = scrollLeft;
+          checkboxes.scrollTop = scrollTop;
+          window.scrollTo(scrollX, scrollY);
         }
       })
       // Keyboard navigation of the menu
@@ -1374,8 +1374,8 @@
       var speed = this.speed;
       var options = this.options;
       var effect = options.openEffect;
-		var scrollX = window.scrollX;
-		var scrollY = window.scrollY;       
+      var scrollX = window.scrollX;
+      var scrollY = window.scrollY;
 
       // figure out opening effects/speeds
       if (effect && effect.constructor == Array) {
@@ -1413,9 +1413,9 @@
       else {
         $header.find('a').first().trigger('focus');
       }
-       
-		// Restore window scroll position if altered by setting element focus
-		window.scrollTo(scrollX, scrollY);
+
+      // Restore window scroll position if altered by setting element focus
+      window.scrollTo(scrollX, scrollY);
 
       $button.addClass('ui-state-active');
       this._isOpen = true;


### PR DESCRIPTION
### multiselect.filter.js:

1.  Make filterRules a local variable.  (missed this before)
2.  Remove the unneeded multiselect() fxn call to get the widget instance--just use data() by itself.  (forgot to attempt this before)
3.  Save additional class names in variables that can be obfuscated away.
4.  Use ui-multiselect-grouplabel class name instead of finding the anchor tag directly.
5.  Decrease unneeded jQuery fxn calls w/ use of classList methods.

No feature changes.  All unit tests pass.

### multiselect.js

Fixes #195
Fixes #551

This fixes undesired scrolling issues caused by focusing an element that is only partially visible.
All unit tests pass.