### PR TITLE
Prevent unwanted hiding of optgroups after refresh

### DIFF
--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -175,7 +175,9 @@
       // show/hide optgroups
       $groups.each(function() {
         var $this = $(this);
-        if(!$this.children("li:visible").length) {
+        // check with a function on display:none css instead of using :visible selector because newly created
+        // (on refresh) items are by default not (yet) visible but not hidden on purpose with the display:none.
+        if(!$this.children('li').filter(function () { return $.css(this, "display") !== 'none' }).length) {
           $this.hide();
         }
       });


### PR DESCRIPTION
Fix same bug as was reported in issue #154.
This original bug was fixed in commit 47854a0 (fix for hiding/showing optgroups when optionlist is hidden) but reintroduced in commit a9fcf40 (Option Groups are now ul elements instead of additional list items. )

Description of problem:
When having optgroups and using filtering in the multiselect, the optgroups get hidden after calling refresh. This problem does not occur when no optgroups are used.

On checking the visibility of the items inside the optgroups the wrong check (:visible selector) was used; the items will not be visible yet. However, they are not hidden on purpose with display:none, so checking on that css is the better way of checking for 'visibility'.