### PR TITLE
Version 2 to Version 3 Migrate Function

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -141,6 +141,12 @@
     *   - Calls refresh to populate the menu
     */
    _create: function() {
+      
+      // Convert version style 2 options.
+      if (this._migrateOptions && typeof this._migrateOptions === 'function') {
+         this._migrateOptions();
+      }
+      
       var $element = this.element;
       var elSelect = $element[0];
       var options = this.options;

--- a/src/migrate.multiselect.js
+++ b/src/migrate.multiselect.js
@@ -1,0 +1,33 @@
+// Load this JavaScript file *after* the main jquery.multiselect.js file.
+
+/**
+* Converts Version 2 style jQuery UI multiselect options to Version 3.
+*/
+
+$.ech.multiselect.prototype._migrateOptions = function() {
+   var options = this.options;
+
+   // Renamed options
+   var renamed =  { 'height' : 'menuHeight', 'hide' : 'closeEffect', 'minWidth' : 'buttonWidth', 'show' : 'openEffect' };
+   for (name in renamed) {
+      if (name in options) {
+         options[ renamed[ name ] ] = options[ name ];
+      }
+   }
+
+   // New option usage
+   if ('multiple' in options) {
+      this.element[0].multiple == !!options.multiple ? 'multiple' : '';
+   }
+   if ('showCheckAll' in options || 'showUncheckAll' in options) {
+      options.header = ( !!options.showCheckAll ? ['checkAll'] : [] ).concat( !!options.showUncheckAll ? ['uncheckAll'] : [] );
+   }
+   if ('checkAllText' in options || 'uncheckAllText' in options || 'closeIcon' in options) {
+      options.linkInfo = $.extend( {},
+                                       !!options.checkAllText ? {'checkAll' : {'text' : options.checkAllText} } : {},
+                                       !!options.uncheckAllText ? {'uncheckAll' : {'text' : options.uncheckAllText} } : {},
+                                       !!options.closeIcon ? {'close' : {'icon' : options.closeIcon} } : {},
+                                       options.linkInfo || {}
+                                    );
+   }
+};


### PR DESCRIPTION
I created a migrate function to make it easier for current widget users to migrate to Version 3. 

* Create migrate.multiselect.js

* Add _migrateOptions() function