### PR TITLE
Update animation support

### DIFF
--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -4,7 +4,7 @@
 .ui-multiselect-menu { display:none; box-sizing:border-box; position:absolute; text-align:left; z-index: 101; width:auto; height:auto; padding:3px; }
 .ui-multiselect-menu.ui-multiselect-listbox {position:relative; z-index: 0;}
 
-.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom: 2px;}
+.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom:3px;}
 .ui-multiselect-header > ul { font-size:0.9em }
 .ui-multiselect-header li { float:left; margin:0 10px 0 0;}
 .ui-multiselect-header a { text-decoration:none; }
@@ -12,7 +12,7 @@
 .ui-multiselect-header .ui-icon { float:left; }
 .ui-multiselect-header .ui-multiselect-close { float:right; margin-right:0; text-align:right; }
 
-.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0; padding: 4px 0 8px;}
+.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0;}
 .ui-multiselect-checkboxes li:not(.ui-multiselect-optgroup) { clear:both; font-size:0.9em; list-style: none; padding-right:3px;}
 .ui-multiselect-checkboxes label { border:1px solid transparent; cursor:default; display:block; padding:3px 1px;}
 .ui-multiselect-checkboxes input { position:relative; top:1px; cursor: pointer;}

--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -4,7 +4,7 @@
 .ui-multiselect-menu { display:none; box-sizing:border-box; position:absolute; text-align:left; z-index: 101; width:auto; height:auto; padding:3px; }
 .ui-multiselect-menu.ui-multiselect-listbox {position:relative; z-index: 0;}
 
-.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom:3px;}
+.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom: 2px;}
 .ui-multiselect-header > ul { font-size:0.9em }
 .ui-multiselect-header li { float:left; margin:0 10px 0 0;}
 .ui-multiselect-header a { text-decoration:none; }
@@ -12,7 +12,7 @@
 .ui-multiselect-header .ui-icon { float:left; }
 .ui-multiselect-header .ui-multiselect-close { float:right; margin-right:0; text-align:right; }
 
-.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0;}
+.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0; padding: 4px 0 8px;}
 .ui-multiselect-checkboxes li:not(.ui-multiselect-optgroup) { clear:both; font-size:0.9em; list-style: none; padding-right:3px;}
 .ui-multiselect-checkboxes label { border:1px solid transparent; cursor:default; display:block; padding:3px 1px;}
 .ui-multiselect-checkboxes input { position:relative; top:1px; cursor: pointer;}

--- a/demos/animations.htm
+++ b/demos/animations.htm
@@ -14,15 +14,15 @@
 <script type="text/javascript">
 $(function(){
 
-   $("#test-1").multiselect({
-      show: ["bounce", 200],
-      hide: ["explode", 1000]
-   });
-   
-   $("#test-2").multiselect({
-      show: "bounce",
-      hide: "explode"
-   });
+	$("#test-1").multiselect({
+		openEffect: ["bounce", 200],
+		closeEffect: ["explode", 1000]
+	});
+	
+	$("#test-2").multiselect({
+		openEffect: "bounce",
+		closeEffect: "explode"
+	});
 
 });
 </script>
@@ -30,14 +30,13 @@ $(function(){
 <body onload="prettyPrint();">
 
 <h2>Show/hide with Animation</h2>
-<p>Using animations with the show and hide parameters.  Either pass an array with the effect name and the speed, or just specify the name of an effect.  If you don't
-specify a speed, the default of 400ms will be used.</p>
+<p>Using animations with the openEffect and closeEffect parameters.  Either pass an array with the effect name and the speed, an object of animation parameters, or just specify the name of an effect.  If you don't specify a speed, the default of 400ms will be used.</p>
 
 <h3>Specifying different show and hide speeds</h3>
 <pre class="prettyprint">
 $("#test-1").multiselect({
-   show: ["bounce", 200],
-   hide: ["explode", 1000]
+   openEffect: ["bounce", 200],
+   closeEffect: ["explode", 1000]
 });
 </pre>
 <select id="test-1" multiple="multiple" size="5">
@@ -51,8 +50,8 @@ $("#test-1").multiselect({
 <h3>Only passing the name of an effect</h3>
 <pre class="prettyprint">
 $("#test-2").multiselect({
-   show: "bounce",
-   hide: "explode"
+   openEffect: "bounce",
+   closeEffect: "explode"
 });
 </pre>
 <select id="test-2" multiple="multiple" size="5">

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1371,25 +1371,22 @@
       var $header = this.$header;
       var $labels = this.$labels;
       var $inputs = this.$inputs.filter(':checked:not(.ui-state-disabled)');
-      var speed = this.speed;
       var options = this.options;
       var effect = options.openEffect;
       var scrollX = window.scrollX;
       var scrollY = window.scrollY;
 
-      // figure out opening effects/speeds
-      if (effect && effect.constructor == Array) {
-        speed = effect[1] || speed;
-        effect = effect[0];
-      }
-
       // set the scroll of the checkbox container
       this.$checkboxes.scrollTop(0);
 
       // show the menu, maybe with a speed/effect combo
-      // if there's an effect, assume jQuery UI is in use
-      if (effect) {
-         $.fn.show.apply($menu, effect ? [ effect, speed ] : []);
+      if (!!effect && typeof effect == 'object') {
+         if (effect.constructor == Array) {
+            $.fn.show.call($menu, effect[0], effect[1] || this.speed);
+         }
+         else if (effect.constructor == Object) {
+            $.fn.show.call($menu, effect);
+         }
       }
       else {
          $menu.css('display','block');
@@ -1433,19 +1430,16 @@
 
       var options = this.options;
       var effect = options.closeEffect;
-      var speed = this.speed;
       var $button = this.$button;
 
-      // figure out closing effects/speeds
-      if (effect && effect.constructor == Array) {
-        speed = effect[1] || speed;
-        effect = effect[0];
-      }
-
       // hide the menu, maybe with a speed/effect combo
-      // if there's an effect, assume jQuery UI is in use
-      if (effect) {
-         $.fn.hide.apply(this.$menu, effect ? [ effect, speed ] : []);
+      if (!!effect && typeof effect == 'object') {
+         if (effect.constructor == Array) {
+            $.fn.hide.call($menu, effect[0], effect[1] || this.speed);
+         }
+         else if (effect.constructor == Object) {
+            $.fn.hide.call($menu, effect);
+         }
       }
       else {
          this.$menu.css('display','none');

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1380,11 +1380,14 @@
       this.$checkboxes.scrollTop(0);
 
       // show the menu, maybe with a speed/effect combo
-      if (!!effect && typeof effect == 'object') {
-         if (effect.constructor == Array) {
+      if (!!effect) {
+         if (typeof effect == 'string') {
+            $.fn.show.call($menu, effect, this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Array) {
             $.fn.show.call($menu, effect[0], effect[1] || this.speed);
          }
-         else if (effect.constructor == Object) {
+         else if (typeof effect == 'object' && effect.constructor == Object) {
             $.fn.show.call($menu, effect);
          }
       }
@@ -1421,28 +1424,30 @@
 
     // Close the menu
     close: function() {
-      var self = this;
-
       // bail if the multiselect close event returns false
       if (this._trigger('beforeclose') === false || !!this.options.listbox) {
         return;
       }
 
+      var $menu = this.$menu;
       var options = this.options;
       var effect = options.closeEffect;
       var $button = this.$button;
 
       // hide the menu, maybe with a speed/effect combo
-      if (!!effect && typeof effect == 'object') {
-         if (effect.constructor == Array) {
+      if (!!effect) {
+         if (typeof effect == 'string') {
+            $.fn.hide.call($menu, effect, this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Array) {
             $.fn.hide.call($menu, effect[0], effect[1] || this.speed);
          }
-         else if (effect.constructor == Object) {
+         else if (typeof effect == 'object' && effect.constructor == Object) {
             $.fn.hide.call($menu, effect);
          }
       }
       else {
-         this.$menu.css('display','none');
+         $menu.css('display','none');
       }
 
       $button.removeClass('ui-state-active').trigger('blur').trigger('mouseleave');


### PR DESCRIPTION
Closes #758.

Aligns animation options with current .show() & .hide() signatures.

The current array object support for the openEffect and closeEffect options is maintained.
It does align with the current `.show( effect [, options ] [, duration ] [, complete ] )` signature (or for `hide`), for the case of the `[, options ]` and `[, complete ]` parameters being omitted, since the two array parameters are supplied for the effect and duration parameters.

However, support for a plain object of animation settings for the openEffect and closeEffect options is also now supported.  This aligns with the current `.show( options )` signature (or for `hide`), and allows the easing to be specified in the object.