### PR TITLE
Fix #770 - Scroll on Focus w/ _traverse()

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1381,24 +1381,25 @@
       // set the scroll of the checkbox container
       this.$checkboxes.scrollTop(0);
 
-      // Show the menu, set its dimensions, and position it.
-      $menu.css('display','block');
+      // show the menu, maybe with a speed/effect combo
+      if (!!effect) {
+         if (typeof effect == 'string') {
+            $.fn.show.call($menu, effect, this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Array) {
+            $.fn.show.call($menu, effect[0], effect[1] || this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Object) {
+            $.fn.show.call($menu, effect);
+         }
+      }
+      else {
+         $menu.css('display','block');
+      }
+
       this._setMenuWidth();
       this._setMenuHeight();
       this.position();
-
-      // Do any specified open animation effect after positioning the menu.
-      if (!!effect) {
-         if (typeof effect == 'string') {
-            $menu.effect(effect, this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Array) {
-            $menu.effect(effect[0], effect[1] || this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Object) {
-            $menu.effect(effect);
-         }
-      }
 
       // focus the first not disabled option or filter input if available
       var filter = $header.find(".ui-multiselect-filter");
@@ -1438,13 +1439,13 @@
       // hide the menu, maybe with a speed/effect combo
       if (!!effect) {
          if (typeof effect == 'string') {
-            $menu.hide(effect, this.speed);
+            $.fn.hide.call($menu, effect, this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Array) {
-            $menu.hide(effect[0], effect[1] || this.speed);
+            $.fn.hide.call($menu, effect[0], effect[1] || this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Object) {
-            $menu.hide(effect);
+            $.fn.hide.call($menu, effect);
          }
       }
       else {
@@ -1452,7 +1453,6 @@
       }
 
       $button.removeClass('ui-state-active').trigger('blur').trigger('mouseleave');
-      this.element.trigger('blur');    // For jQuery Validate
       this._isOpen = false;
       this._trigger('close');
       $button.trigger('focus');

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1381,25 +1381,24 @@
       // set the scroll of the checkbox container
       this.$checkboxes.scrollTop(0);
 
-      // show the menu, maybe with a speed/effect combo
-      if (!!effect) {
-         if (typeof effect == 'string') {
-            $.fn.show.call($menu, effect, this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Array) {
-            $.fn.show.call($menu, effect[0], effect[1] || this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Object) {
-            $.fn.show.call($menu, effect);
-         }
-      }
-      else {
-         $menu.css('display','block');
-      }
-
+      // Show the menu, set its dimensions, and position it.
+      $menu.css('display','block');
       this._setMenuWidth();
       this._setMenuHeight();
       this.position();
+
+      // Do any specified open animation effect after positioning the menu.
+      if (!!effect) {
+         if (typeof effect == 'string') {
+            $menu.effect(effect, this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Array) {
+            $menu.effect(effect[0], effect[1] || this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Object) {
+            $menu.effect(effect);
+         }
+      }
 
       // focus the first not disabled option or filter input if available
       var filter = $header.find(".ui-multiselect-filter");
@@ -1439,13 +1438,13 @@
       // hide the menu, maybe with a speed/effect combo
       if (!!effect) {
          if (typeof effect == 'string') {
-            $.fn.hide.call($menu, effect, this.speed);
+            $menu.hide(effect, this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Array) {
-            $.fn.hide.call($menu, effect[0], effect[1] || this.speed);
+            $menu.hide(effect[0], effect[1] || this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Object) {
-            $.fn.hide.call($menu, effect);
+            $menu.hide(effect);
          }
       }
       else {
@@ -1453,6 +1452,7 @@
       }
 
       $button.removeClass('ui-state-active').trigger('blur').trigger('mouseleave');
+      this.element.trigger('blur');    // For jQuery Validate
       this._isOpen = false;
       this._trigger('close');
       $button.trigger('focus');

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -729,7 +729,7 @@
          this.classList.remove('ui-state-hover');
       })
       // option label
-      .on('mouseenter.multiselect', 'label', function() {
+      .on('mouseenter.multiselect', 'label', function(e, param) {
         if (!this.classList.contains('ui-state-disabled')) {
           var checkboxes = self.$checkboxes[0];
           var scrollLeft = checkboxes.scrollLeft;
@@ -741,9 +741,11 @@
           $(this).addClass('ui-state-hover').find('input').focus();
 
           // Restore scroll positions if altered by setting input focus
-          checkboxes.scrollLeft = scrollLeft;
-          checkboxes.scrollTop = scrollTop;
-          window.scrollTo(scrollX, scrollY);
+          if ( !param || !param.allowScroll ) {
+            checkboxes.scrollLeft = scrollLeft;
+            checkboxes.scrollTop = scrollTop;
+            window.scrollTo(scrollX, scrollY);
+          }
         }
       })
       // Keyboard navigation of the menu
@@ -1231,13 +1233,13 @@
         var $container = this.$menu.find('ul').last();
 
         // move to the first/last
-        this.$menu.find('label').filter(':visible')[ moveToLast ? 'last' : 'first' ]().trigger('mouseover');
+        this.$menu.find('label').filter(':visible')[ moveToLast ? 'last' : 'first' ]().trigger('mouseover', {allowScroll: true});
 
         // set scroll position
         $container.scrollTop(moveToLast ? $container.height() : 0);
       }
       else {
-        $next.find('label').filter(':visible')[ moveToLast ? "last" : "first" ]().trigger('mouseover');
+        $next.find('label').filter(':visible')[ moveToLast ? "last" : "first" ]().trigger('mouseover', {allowScroll: true});
       }
     },
 


### PR DESCRIPTION
Fix #770 

Added a parameter to allow _traversing() to allow scrolling (unlock scroll position) on input focus when changing focus via keyboard traversing.  