### PR TITLE
Use $.outerWidth() for Native Select Element Width

### DIFF
--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -4,7 +4,7 @@
 .ui-multiselect-menu { display:none; box-sizing:border-box; position:absolute; text-align:left; z-index: 101; width:auto; height:auto; padding:3px; }
 .ui-multiselect-menu.ui-multiselect-listbox {position:relative; z-index: 0;}
 
-.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom:3px;}
+.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom:2px;}
 .ui-multiselect-header > ul { font-size:0.9em }
 .ui-multiselect-header li { float:left; margin:0 10px 0 0;}
 .ui-multiselect-header a { text-decoration:none; }
@@ -12,7 +12,7 @@
 .ui-multiselect-header .ui-icon { float:left; }
 .ui-multiselect-header .ui-multiselect-close { float:right; margin-right:0; text-align:right; }
 
-.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0;}
+.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0; padding: 4px 0 8px;}
 .ui-multiselect-checkboxes li:not(.ui-multiselect-optgroup) { clear:both; font-size:0.9em; list-style: none; padding-right:3px;}
 .ui-multiselect-checkboxes label { border:1px solid transparent; cursor:default; display:block; padding:3px 1px;}
 .ui-multiselect-checkboxes input { position:relative; top:1px; cursor: pointer;}

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -150,7 +150,7 @@
       var linkInfo = ( this.linkInfo = $.extend(true, {}, linkDefaults, options.linkInfo || {}) );
 
       // grab select width before hiding it
-      this._selectWidth = this._getBCRWidth(elSelect);
+      this._selectWidth = $element.outerWidth();
       $element.hide();
 
       // Convert null/falsely option values to empty arrays for fewer problems

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1381,24 +1381,25 @@
       // set the scroll of the checkbox container
       this.$checkboxes.scrollTop(0);
 
-      // Show the menu, set its dimensions, and position it.
-      $menu.css('display','block');
+      // show the menu, maybe with a speed/effect combo
+      if (!!effect) {
+         if (typeof effect == 'string') {
+            $.fn.show.call($menu, effect, this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Array) {
+            $.fn.show.call($menu, effect[0], effect[1] || this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Object) {
+            $.fn.show.call($menu, effect);
+         }
+      }
+      else {
+         $menu.css('display','block');
+      }
+
       this._setMenuWidth();
       this._setMenuHeight();
       this.position();
-
-      // Do any specified open animation effect after positioning the menu.
-      if (!!effect) {
-         if (typeof effect == 'string') {
-            $menu.effect(effect, this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Array) {
-            $menu.effect(effect[0], effect[1] || this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Object) {
-            $menu.effect(effect);
-         }
-      }
 
       // focus the first not disabled option or filter input if available
       var filter = $header.find(".ui-multiselect-filter");
@@ -1438,13 +1439,13 @@
       // hide the menu, maybe with a speed/effect combo
       if (!!effect) {
          if (typeof effect == 'string') {
-            $menu.hide(effect, this.speed);
+            $.fn.hide.call($menu, effect, this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Array) {
-            $menu.hide(effect[0], effect[1] || this.speed);
+            $.fn.hide.call($menu, effect[0], effect[1] || this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Object) {
-            $menu.hide(effect);
+            $.fn.hide.call($menu, effect);
          }
       }
       else {
@@ -1452,7 +1453,6 @@
       }
 
       $button.removeClass('ui-state-active').trigger('blur').trigger('mouseleave');
-      this.element.trigger('blur');    // For jQuery Validate
       this._isOpen = false;
       this._trigger('close');
       $button.trigger('focus');

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1381,25 +1381,24 @@
       // set the scroll of the checkbox container
       this.$checkboxes.scrollTop(0);
 
-      // show the menu, maybe with a speed/effect combo
-      if (!!effect) {
-         if (typeof effect == 'string') {
-            $.fn.show.call($menu, effect, this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Array) {
-            $.fn.show.call($menu, effect[0], effect[1] || this.speed);
-         }
-         else if (typeof effect == 'object' && effect.constructor == Object) {
-            $.fn.show.call($menu, effect);
-         }
-      }
-      else {
-         $menu.css('display','block');
-      }
-
+      // Show the menu, set its dimensions, and position it.
+      $menu.css('display','block');
       this._setMenuWidth();
       this._setMenuHeight();
       this.position();
+
+      // Do any specified open animation effect after positioning the menu.
+      if (!!effect) {
+         if (typeof effect == 'string') {
+            $menu.effect(effect, this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Array) {
+            $menu.effect(effect[0], effect[1] || this.speed);
+         }
+         else if (typeof effect == 'object' && effect.constructor == Object) {
+            $menu.effect(effect);
+         }
+      }
 
       // focus the first not disabled option or filter input if available
       var filter = $header.find(".ui-multiselect-filter");
@@ -1439,13 +1438,13 @@
       // hide the menu, maybe with a speed/effect combo
       if (!!effect) {
          if (typeof effect == 'string') {
-            $.fn.hide.call($menu, effect, this.speed);
+            $menu.hide(effect, this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Array) {
-            $.fn.hide.call($menu, effect[0], effect[1] || this.speed);
+            $menu.hide(effect[0], effect[1] || this.speed);
          }
          else if (typeof effect == 'object' && effect.constructor == Object) {
-            $.fn.hide.call($menu, effect);
+            $menu.hide(effect);
          }
       }
       else {
@@ -1453,6 +1452,7 @@
       }
 
       $button.removeClass('ui-state-active').trigger('blur').trigger('mouseleave');
+      this.element.trigger('blur');    // For jQuery Validate
       this._isOpen = false;
       this._trigger('close');
       $button.trigger('focus');

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -492,7 +492,7 @@
 
       // If the filter widget is in use, then also update its cache.
       if ( this.element.is(':data("ech-multiselectfilter")') ) {
-            this.element.multiselectfilter('instance').updateCache(true);
+            this.element.data('ech-multiselectfilter').updateCache(true);
       }
     },
 

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1118,10 +1118,11 @@
          // Deduct height of header & border/padding to find height available for checkboxes.
          var $header = self.$header.filter(':visible');
          var headerHeight = $header.outerHeight(true) + self._jqHeightFix($header);
-         var borderPaddingHt = this.$menu.outerHeight(false) - this.$menu.height();
+         var menuBorderPaddingHt = this.$menu.outerHeight(false) - this.$menu.height();
+         var cbBorderPaddingHt = this.$checkboxes.outerHeight(false) - this.$checkboxes.height();
 
          optionHeight = self._parse2px(optionHeight, self.element, true).px;
-         maxHeight = Math.min(optionHeight, maxHeight) - headerHeight - borderPaddingHt;
+         maxHeight = Math.min(optionHeight, maxHeight) - headerHeight - menuBorderPaddingHt - cbBorderPaddingHt;
       }
       else if (optionHeight.toLowerCase() === 'size') {
          // Overall height based on native select 'size' attribute

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -729,7 +729,7 @@
          this.classList.remove('ui-state-hover');
       })
       // option label
-      .on('mouseenter.multiselect', 'label', function() {
+      .on('mouseenter.multiselect', 'label', function(e, param) {
         if (!this.classList.contains('ui-state-disabled')) {
           var checkboxes = self.$checkboxes[0];
           var scrollLeft = checkboxes.scrollLeft;
@@ -741,9 +741,11 @@
           $(this).addClass('ui-state-hover').find('input').focus();
 
           // Restore scroll positions if altered by setting input focus
-          checkboxes.scrollLeft = scrollLeft;
-          checkboxes.scrollTop = scrollTop;
-          window.scrollTo(scrollX, scrollY);
+          if ( !param || !param.allowScroll ) {
+            checkboxes.scrollLeft = scrollLeft;
+            checkboxes.scrollTop = scrollTop;
+            window.scrollTo(scrollX, scrollY);
+          }
         }
       })
       // Keyboard navigation of the menu
@@ -1231,13 +1233,13 @@
         var $container = this.$menu.find('ul').last();
 
         // move to the first/last
-        this.$menu.find('label').filter(':visible')[ moveToLast ? 'last' : 'first' ]().trigger('mouseover');
+        this.$menu.find('label').filter(':visible')[ moveToLast ? 'last' : 'first' ]().trigger('mouseover', {allowScroll: true});
 
         // set scroll position
         $container.scrollTop(moveToLast ? $container.height() : 0);
       }
       else {
-        $next.find('label').filter(':visible')[ moveToLast ? "last" : "first" ]().trigger('mouseover');
+        $next.find('label').filter(':visible')[ moveToLast ? "last" : "first" ]().trigger('mouseover', {allowScroll: true});
       }
     },
 


### PR DESCRIPTION
This is a bug fix.

When the widget is created in the create() event of a dialog, the native select will be hidden and _getBCRWidth() will return a zero width.   Therefore, $.outerWidth() must be used to retrieve the native select's width in _create(), since $.outerWidth() will unhide the select to get the width.