### PR TITLE
Use $.outerWidth() for Native Select Element Width

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -150,7 +150,7 @@
       var linkInfo = ( this.linkInfo = $.extend(true, {}, linkDefaults, options.linkInfo || {}) );
 
       // grab select width before hiding it
-      this._selectWidth = this._getBCRWidth(elSelect);
+      this._selectWidth = $element.outerWidth();
       $element.hide();
 
       // Convert null/falsely option values to empty arrays for fewer problems


### PR DESCRIPTION
Native Select element could be initially hidden in the case of a dialog.

### This Pull Request is a
 - [x] Bug fix
 - [ ] Feature addition
 - [ ] Code refactoring / optimization
 - [ ] Test Addition
 - [ ] Demo Addition
 - [ ] i18n Addition
 - [ ] Other (explain below)
 
### Related Issue numbers _(use [Github "keywords"](https://help.github.com/articles/closing-issues-using-keywords/): Fixes #nnn, Closes #nnn, etc.)_
n/a

### What changes are you proposing?  Why are they needed?<br>
_(Provide use cases, code references, [jsfiddle](https://jsfiddle.net/), [codepen](https://codepen.io), etc.)_
If the native select is initially hidden in the case of a dialog, the initial width determination will need to be done w/ $.outerWidth() instead of _getBCRWidth().
  
### Pull Request Approval Checklist:
  - [x] No Tabs / Code Spacing Consistent
  - [x] Tests Ran and 0 Failing
  - [x] Tests Added/Updated
  - [x] Impacted Demos Updated
  - [x] Impacted i18n Code Updated
  
### @Mentions:
@mlh758 