### PR TITLE
Eliminate Trailing New Lines from Unterminated Option Text

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -549,7 +549,8 @@
           value = selectedText.call(self, numChecked, inputCount, $checked.get());
         }
         else if (/\d/.test(selectedList) && selectedList > 0 && numChecked <= selectedList) {
-          value = $checked.map(function() { return $(this).next().text() }).get().join(options.selectedListSeparator);
+          value = $checked.map(function() { return $(this).next().text().replace(/\n$/, '') })
+                          .get().join(options.selectedListSeparator);
         }
         else {
           value = selectedText.replace('#', numChecked).replace('#', inputCount);


### PR DESCRIPTION
This very small change prevents browsers from converting trailing newlines to spaces when using the selectedList option and the underlying select lacks closing &lt;/option&gt; tags.  Without this, it looks like there are extra spaces added to the untrained eye. (it is just the newlines that get converted)

### This Pull Request is a
 - [x] Bug fix
 -  Feature addition
 -  Code refactoring / optimization
 -  Test Addition
 -  Demo Addition
 -  i18n Addition
 -  Other (explain below)
   
### Related Issue numbers _(use [Github "keywords"](https://help.github.com/articles/closing-issues-using-keywords/): Fixes #nnn, Closes #nnn, etc.)_   
n/a
   
### What changes are you proposing?  Why are they needed?<br>
_(Provide use cases, code references, [jsfiddle](https://jsfiddle.net/), [codepen](https://codepen.io), etc.)_   

The added .replace(/\n$/, '') just takes off the unnecessary ending newline that is part of the option text when no &lt;/option&gt; tags are used.
  
### Pull Request Approval Checklist:
  - [x] No Tabs / Code Spacing Consistent
  - [x] Tests Ran and 0 Failing
  - [x] Tests Added/Updated
  - [x] Impacted Demos Updated
  - [x] Impacted i18n Code Updated
  
### @Mentions:
@mlh758 