### PR TITLE
Update jquery.multiselect.css

### DIFF
--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -24,7 +24,7 @@
 .ui-multiselect-collapsed > ul { display:none }
 
 .ui-multiselect-single .ui-multiselect-checkboxes input { left:-9999px; position:absolute !important; top: auto !important; }
-.ui-multiselect-single .ui-multiselect-checkboxes label { padding:5px !important }
+.ui-multiselect-single .ui-multiselect-checkboxes label { padding:5px !important; text-indent: 0 !important; }
 
 .ui-multiselect.ui-multiselect-nowrap { white-space: nowrap }
 .ui-multiselect.ui-multiselect-nowrap > span { display: inline-block }


### PR DESCRIPTION
PR #798 implemented hanging indents for multiple indents, but that broke the indents for single selects.

This fixes the indents for single-selects.

### This Pull Request is a
 - [x] Bug fix
 - [ ] Feature addition
 - [ ] Code refactoring / optimization
 - [ ] Test Addition
 - [ ] Demo Addition
 - [ ] i18n Addition
 - [ ] Other (explain below)
   
### Related Issue numbers _(use [Github "keywords"](https://help.github.com/articles/closing-issues-using-keywords/): Fixes #nnn, Closes #nnn, etc.)_   
PR #798
   
### What changes are you proposing?  Why are they needed?<br>
_(Provide use cases, code references, [jsfiddle](https://jsfiddle.net/), [codepen](https://codepen.io), etc.)_   

PR #798 implemented hanging indents for multiple indents, but that broke the indents for single selects.

This fixes the indents for single-selects.
  
### Pull Request Approval Checklist:
  - [x] No Tabs / Code Spacing Consistent
  - [x] Tests Ran and 0 Failing
  - [x] Tests Added/Updated
  - [x] Impacted Demos Updated
  - [x] Impacted i18n Code Updated
  
### @Mentions:
@mlh758 
