### PR TITLE
Better handling of case of both buttonWidth and menuWidth options set to 'auto'

### DIFF
--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -14,7 +14,7 @@
 
 .ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0; padding: 4px 0 8px;}
 .ui-multiselect-checkboxes li:not(.ui-multiselect-optgroup) { clear:both; font-size:0.9em; list-style: none; padding-right:3px;}
-.ui-multiselect-checkboxes label { border:1px solid transparent; cursor:default; display:block; padding:3px 1px;}
+.ui-multiselect-checkboxes label { border:1px solid transparent; cursor:default; display:block; padding:3px 1px 3px 21px; text-indent: -20px;}
 .ui-multiselect-checkboxes input { position:relative; top:1px; cursor: pointer;}
 .ui-multiselect-checkboxes img { height: 30px; vertical-align: middle; margin-right: 3px;}
 .ui-multiselect-grouplabel { border-bottom:1px solid; cursor: pointer; display:block; font-weight:bold; margin:1px 0; padding:3px; text-align:center; text-decoration:none; }

--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -4,7 +4,7 @@
 .ui-multiselect-menu { display:none; box-sizing:border-box; position:absolute; text-align:left; z-index: 101; width:auto; height:auto; padding:3px; }
 .ui-multiselect-menu.ui-multiselect-listbox {position:relative; z-index: 0;}
 
-.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom:3px;}
+.ui-multiselect-header { display:block; box-sizing:border-box; position:relative; width:auto; padding:3px 0 3px 4px; margin-bottom:2px;}
 .ui-multiselect-header > ul { font-size:0.9em }
 .ui-multiselect-header li { float:left; margin:0 10px 0 0;}
 .ui-multiselect-header a { text-decoration:none; }
@@ -12,7 +12,7 @@
 .ui-multiselect-header .ui-icon { float:left; }
 .ui-multiselect-header .ui-multiselect-close { float:right; margin-right:0; text-align:right; }
 
-.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0;}
+.ui-multiselect-checkboxes { display:block; box-sizing:border-box; position:relative; overflow:auto; width: auto; border: 0; padding: 4px 0 8px;}
 .ui-multiselect-checkboxes li:not(.ui-multiselect-optgroup) { clear:both; font-size:0.9em; list-style: none; padding-right:3px;}
 .ui-multiselect-checkboxes label { border:1px solid transparent; cursor:default; display:block; padding:3px 1px;}
 .ui-multiselect-checkboxes input { position:relative; top:1px; cursor: pointer;}

--- a/css/jquery.multiselect.css
+++ b/css/jquery.multiselect.css
@@ -24,7 +24,7 @@
 .ui-multiselect-collapsed > ul { display:none }
 
 .ui-multiselect-single .ui-multiselect-checkboxes input { left:-9999px; position:absolute !important; top: auto !important; }
-.ui-multiselect-single .ui-multiselect-checkboxes label { padding:5px !important }
+.ui-multiselect-single .ui-multiselect-checkboxes label { padding:5px !important; text-indent: 0 !important; }
 
 .ui-multiselect.ui-multiselect-nowrap { white-space: nowrap }
 .ui-multiselect.ui-multiselect-nowrap > span { display: inline-block }

--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -222,6 +222,7 @@
       }
       if (!this.instance.options.listbox && this.instance._isOpen) {
          this.instance._setMenuHeight(true);
+         this.instance.position();
       }
       return;
     },

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -549,7 +549,8 @@
           value = selectedText.call(self, numChecked, inputCount, $checked.get());
         }
         else if (/\d/.test(selectedList) && selectedList > 0 && numChecked <= selectedList) {
-          value = $checked.map(function() { return $(this).next().text() }).get().join(options.selectedListSeparator);
+          value = $checked.map(function() { return $(this).next().text().replace(/\n$/, '') })
+                          .get().join(options.selectedListSeparator);
         }
         else {
           value = selectedText.replace('#', numChecked).replace('#', inputCount);

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1118,10 +1118,11 @@
          // Deduct height of header & border/padding to find height available for checkboxes.
          var $header = self.$header.filter(':visible');
          var headerHeight = $header.outerHeight(true) + self._jqHeightFix($header);
-         var borderPaddingHt = this.$menu.outerHeight(false) - this.$menu.height();
+         var menuBorderPaddingHt = this.$menu.outerHeight(false) - this.$menu.height();
+         var cbBorderPaddingHt = this.$checkboxes.outerHeight(false) - this.$checkboxes.height();
 
          optionHeight = self._parse2px(optionHeight, self.element, true).px;
-         maxHeight = Math.min(optionHeight, maxHeight) - headerHeight - borderPaddingHt;
+         maxHeight = Math.min(optionHeight, maxHeight) - headerHeight - menuBorderPaddingHt - cbBorderPaddingHt;
       }
       else if (optionHeight.toLowerCase() === 'size') {
          // Overall height based on native select 'size' attribute

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1095,6 +1095,18 @@
       this.$menu.width(contentWidth);
       // Save width including padding and border (no margins) for consistency w/ normal width setting.
       this._savedMenuWidth = this.$menu.outerWidth(false);
+       
+      // Handle case of both buttonWidth and menuWidth options set to 'auto' -- force equal widths.
+      if (!this.options.listbox && this.options.buttonWidth === 'auto' && this._savedMenuWidth !== this._savedButtonWidth) {
+         if (this._savedMenuWidth > this._savedButtonWidth) {
+            this.$button.outerWidth(this._savedMenuWidth);
+            this._savedButtonWidth = this._savedMenuWidth;
+         }
+         else {
+            this.$menu.width(contentWidth + this._savedButtonWidth - this._savedMenuWidth);
+            this._savedMenuWidth = this._savedButtonWidth;
+         }
+      }       
     },
 
     /**

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1117,7 +1117,7 @@
       if ( /\d/.test(optionHeight) ) {
          // Deduct height of header & border/padding to find height available for checkboxes.
          var $header = self.$header.filter(':visible');
-         var headerHeight = $header.outerHeight(true) + self._jqHeightFix($header);
+         var headerHeight = $header.outerHeight(true);
          var menuBorderPaddingHt = this.$menu.outerHeight(false) - this.$menu.height();
          var cbBorderPaddingHt = this.$checkboxes.outerHeight(false) - this.$checkboxes.height();
 
@@ -1133,13 +1133,19 @@
 
       var overflowSetting = 'hidden';
       var itemCount = 0;
-      var ulHeight = 4;  // Adjustment for hover height included here.
+      var hoverAdjust = 4;  // Adjustment for hover height included here.
+      var ulHeight = hoverAdjust;
+      var ulTop = -1;
 
-      // The following adds up item heights.  If the height sum exceeds the option height or if the number
+      // The following determines the how many items are visible per the menuHeight option.
+      //   If the visible height calculation exceeds the calculated maximum height or if the number
       //   of item heights summed equal or exceed the native select size attribute, the loop is aborted.
       // If the loop is aborted, this means that the menu must be scrolled to see all the items.
       self.$checkboxes.find('li:not(.ui-multiselect-optgroup),a').filter(':visible').each( function() {
-        ulHeight += $(this).outerHeight(true) + self._jqHeightFix(this);
+        if (ulTop < 0) {
+           ulTop = this.offsetTop;
+        }
+        ulHeight =  this.offsetTop + this.offsetHeight - ulTop + hoverAdjust;
         if (useSelectSize && ++itemCount >= elSelectSize || ulHeight > maxHeight) {
           overflowSetting = 'auto';
           if (!useSelectSize) {
@@ -1170,20 +1176,6 @@
     },
 
     /**
-     * Calculate accurate outerHeight(false) using getBoundingClientRect()
-     * Note that this presumes that the element is visible in the layout.
-     * @param {node} DOM node or jQuery equivalent to get height for.
-     * @returns {float} Decimal floating point value for the height.
-     */
-   _getBCRHeight: function(elem) {
-      if (!elem || !!elem.jquery && !elem[0]) {
-         return null;
-      }
-      var domRect = !!elem.jquery ? elem[0].getBoundingClientRect() : elem.getBoundingClientRect();
-      return domRect.bottom - domRect.top;
-    },
-
-    /**
      * Calculate jQuery width correction factor to fix floating point round-off errors.
      * Note that this presumes that the element is visible in the layout.
      * @param {node} DOM node or jQuery equivalent to get width for.
@@ -1196,21 +1188,6 @@
       return !!elem.jquery
                   ? this._getBCRWidth(elem[0]) - elem.outerWidth(false)
                   :  this._getBCRWidth(elem) - $(elem).outerWidth(false);
-    },
-
-    /**
-     * Calculate jQuery height correction factor to fix floating point round-off errors.
-     * Note that this presumes that the element is visible in the layout.
-     * @param {node} DOM node or jQuery equivalent to get height for.
-     * @returns {float} Correction value for the height--typically a decimal < 1.0
-     */
-    _jqHeightFix: function(elem) {
-      if (!elem || !!elem.jquery && !elem[0]) {
-         return null;
-      }
-      return !!elem.jquery
-                  ? this._getBCRHeight(elem[0]) - elem.outerHeight(false)
-                  :  this._getBCRHeight(elem) - $(elem).outerHeight(false);
     },
 
     /**


### PR DESCRIPTION
### This Pull Request is a
 - [ ] Bug fix
 - [x] Feature addition
 - [ ] Code refactoring / optimization
 - [ ] Test Addition
 - [ ] Demo Addition
 - [ ] i18n Addition
 - [ ] Other (explain below)
   
### Related Issue numbers _(use [Github "keywords"](https://help.github.com/articles/closing-issues-using-keywords/): Fixes #nnn, Closes #nnn, etc.)_   

n/a
   
### What changes are you proposing?  Why are they needed?<br>
_(Provide use cases, code references, [jsfiddle](https://jsfiddle.net/), [codepen](https://codepen.io), etc.)_   

Handle case of both buttonWidth and menuWidth options set to 'auto' -- force equal widths.
This improves the automatic width determination if both buttonWidth and menuWidth are set to 'auto'.  
  
### Pull Request Approval Checklist:
  - [x] No Tabs / Code Spacing Consistent
  - [x] Tests Ran and 0 Failing
  - [x] Tests Added/Updated
  - [x] Impacted Demos Updated
  - [x] Impacted i18n Code Updated
  
### @Mentions:
@mlh758 