### PR TITLE
Support multiple units for filter input width

### DIFF
--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -93,7 +93,10 @@
           placeholder: opts.placeholder,
           type: "search"
         })
-        .css({  width: (/\d/.test(opts.width) ? opts.width + 'px' : null) });
+        .css({  width: (typeof opts.width === 'string')
+                       ? this.instance._parse2px(opts.width, this.$header).px + 'px'
+                       : (/\d/.test(opts.width) ? opts.width + 'px' : null)
+             });
       this._bindInputEvents();
       // automatically reset the widget on close?
       if (this.options.autoReset) {


### PR DESCRIPTION
### This Pull Request is a
 -  Bug fix
 - [x] Feature addition
 -  Code refactoring / optimization
 -  Test Addition
 -  Demo Addition
 -  i18n Addition
 -  Other (explain below)
   
### Related Issue numbers _(use [Github "keywords"](https://help.github.com/articles/closing-issues-using-keywords/): Fixes #nnn, Closes #nnn, etc.)_   

n/a
   
### What changes are you proposing?  Why are they needed?<br>
_(Provide use cases, code references, [jsfiddle](https://jsfiddle.net/), [codepen](https://codepen.io), etc.)_   

Add ability to specify width of filter input with the same variety of units as is supported for the main widget dimensions.
  
### Pull Request Approval Checklist:
  - [x] No Tabs / Code Spacing Consistent
  - [x] Tests Ran and 0 Failing
  - [x] Tests Added/Updated
  - [x] Impacted Demos Updated
  - [x] Impacted i18n Code Updated
  
### @Mentions:

@mlh758 
