### PR TITLE
Change default collapse/expand icons

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -52,22 +52,22 @@
          'title': 'Flip all'
       },
       'collapse': {
-         'icon': '<span class="ui-icon ui-icon-triangle-1-s"></span>',
+         'icon': '<span class="ui-icon ui-icon-minusthick"></span>',
          'title': 'Collapse'
       },
       'expand': {
-         'icon': '<span class="ui-icon ui-icon-triangle-1-e"></span>',
+         'icon': '<span class="ui-icon ui-icon-plusthick"></span>',
          'title': 'Expand'
       },
       'collapseAll': {
          'class': 'ui-multiselect-collapseall',
-         'icon': '<span class="ui-icon ui-icon-triangle-1-s"></span>',
+         'icon': '<span class="ui-icon ui-icon-minus"></span>',
          'text': 'Collapse all',
          'title': 'Collapse all'
       },
       'expandAll': {
          'class': 'ui-multiselect-expandall',
-         'icon': '<span class="ui-icon ui-icon-triangle-1-e"></span>',
+         'icon': '<span class="ui-icon ui-icon-plus"></span>',
          'text': 'Expand all',
          'title': 'Expand all'
       }


### PR DESCRIPTION
### This Pull Request is a
 - [ ] Bug fix
 - [x] Feature addition / improvement
 - [ ] Code refactoring / optimization
 - [ ] Test Addition
 - [ ] Demo Addition
 - [ ] i18n Addition
 - [ ] Other (explain below)
   
### Related Issue numbers _(use [Github "keywords"](https://help.github.com/articles/closing-issues-using-keywords/): Fixes #nnn, Closes #nnn, etc.)_   
n/a
   
### What changes are you proposing?  Why are they needed?<br>
_(Provide use cases, code references, [jsfiddle](https://jsfiddle.net/), [codepen](https://codepen.io), etc.)_   

Switch default collapse/expand icons to minuses and pluses...   
These seem to be more intuitive than the triangle icons I originally came up with.

  
### Pull Request Approval Checklist:
  - [x] No Tabs / Code Spacing Consistent
  - [x] Tests Ran and 0 Failing
  - [x] Tests Added/Updated
  - [x] Impacted Demos Updated
  - [x] Impacted i18n Code Updated
  
### @Mentions:

@mlh758 