### PR TITLE
fix _toggleDisabled error this.$button is undefined when listbox option is set to true

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1353,8 +1353,10 @@
     _toggleDisabled: function(flag, groupID) {
       var disabledClass = 'ui-state-disabled';  // used for styling only
 
-      this.$button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ](disabledClass);
-
+      if (this.$button) {
+         this.$button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ](disabledClass);
+	  }
+	  
       if (this.options.disableInputsOnToggle) {
          // Apply the ui-multiselect-disabled class name to identify which
          // input elements this widget disabled (not pre-disabled)


### PR DESCRIPTION
This Pull Request is a bug fix

### What changes are you proposing?  Why are they needed?
Check existing of $button inside _toggleDisabled function becase $button is undefined if listbox option is set to true.


### Pull Request Approval Checklist:
  - [x] Tests Ran and 0 Failing
  - [ ] Tests Added/Updated
  - [ ] Impacted Demos Updated
  - [ ] Impacted i18n Code Updated

