### PR TITLE
ISSUE 837: Use jquery offset instead of .position().

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1506,8 +1506,11 @@
         this.$menu.position(this.options.position);
       }
       else {
-        var pos = $button.position();
-        pos.top += this._savedButtonHeight;
+        var pos = {};
+
+        pos.top = $button.offset().top + this._savedButtonHeight;
+        pos.left = $button.offset().left;
+
         this.$menu.offset(pos);
       }
     },


### PR DESCRIPTION
### What changes are you proposing?  Why are they needed?
As i describe in my issue, my menu gets placed in a strange random position.
I found out that the issue is with the jQuery `.position()` function, which for some reason gets confused on my setup.
Both the `left` and `top` properties are wrong - if I base it on the `.offset()` functionality, then it works fine

I have a feeling that this fix can have some pretty crazy consequences - and it really surprises me that noone else seems to have this issue..

<img width="749" alt="Screenshot 2019-03-11 at 16 18 19" src="https://user-images.githubusercontent.com/12376583/54267854-4657da00-457a-11e9-836c-7f4611e98f67.png">


### Related Issue numbers 
https://github.com/ehynds/jquery-ui-multiselect-widget/issues/837


### Pull Request Approval Checklist:
  - [x] Tests Ran and 0 Failing
>"Took 821 ms to run 334 tests. 334 passed, 0 failed."
  - [ ] Tests Added/Updated
  - [ ] Impacted Demos Updated
  - [ ] Impacted i18n Code Updated

