### PR TITLE
Fix compile errors due to reserved word "class"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 docs/public
 docs/_site
 docs/.sass-cache

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -1843,7 +1843,7 @@
         case 'expandAllText':
           if (key !== 'checkAllText' || !this.options.maxSelected) {
             // eq(-1) finds the last span
-            $header.find('a.' + this.linkInfo[key.replace('Text','')].class + ' span').eq(-1).html(value);
+            $header.find('a.' + this.linkInfo[key.replace('Text','')]['class'] + ' span').eq(-1).html(value);
           }
           break;
         case 'checkAllIcon':
@@ -1853,7 +1853,7 @@
         case 'expandAllIcon':
           if (key !== 'checkAllIcon' || !this.options.maxSelected) {
             // eq(0) finds the first span
-            $header.find('a.' + this.linkInfo[key.replace('Icon','')].class + ' span').eq(0).replaceWith(value);
+            $header.find('a.' + this.linkInfo[key.replace('Icon','')]['class'] + ' span').eq(0).replaceWith(value);
           }
           break;
         case 'openIcon':


### PR DESCRIPTION
"class"is a reserved word in javascript.  See [this reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/class).  yuicompressor flags its use as a syntax error as described in #846.

This patch avoids using the reserved word by making the references using array reference syntax instead.

### Related Issue numbers 
Fixes #846


### Pull Request Approval Checklist:
  - [ ] Tests Ran and 0 Failing
  - [ ] Tests Added/Updated
  - [ ] Impacted Demos Updated
  - [ ] Impacted i18n Code Updated

