### PR TITLE
Fix undefined function error _parse2px()

### DIFF
--- a/src/jquery.multiselect.filter.js
+++ b/src/jquery.multiselect.filter.js
@@ -94,14 +94,14 @@
           type: "search"
         })
         .css({  width: (typeof opts.width === 'string')
-                       ? this.instance._parse2px(opts.width, this.$header).px + 'px'
+                       ? this.instance.parse2px(opts.width, this.$header).px + 'px'
                        : (/\d/.test(opts.width) ? opts.width + 'px' : null)
              });
       this._bindInputEvents();
       // automatically reset the widget on close?
       if (this.options.autoReset) {
         $element.on('multiselectbeforeclose', $.proxy(this._reset, this));
-      }        
+      }
 
       var $label = $(document.createElement('label')).text(opts.label).append(this.$input).addClass('ui-multiselect-filter-label');
       this.$wrapper = $(document.createElement('div'))

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -76,7 +76,7 @@
    /**
     * Checks an option element for data-image-src
     * and adds that as an image tag within the widget option
-    * 
+    *
     * @param {Node} option to pull an image from
     * @param {Node} span to insert image tag into
     */
@@ -104,7 +104,7 @@
   /**
    * Creates a jQuery object from the input element
    * This can be a string selector, Node, or jQuery object
-   * @param {(object|string)} elem 
+   * @param {(object|string)} elem
    */
   function getjQueryFromElement(elem) {
     if(!!elem.jquery) {
@@ -197,7 +197,8 @@
       disableInputsOnToggle: true,        // (true | false)  If true, each individual checkbox input is also disabled when the widget is disabled.
       groupsSelectable: true,             // (true | false) Determines if clicking on an option group heading selects all of its options.
       groupsCollapsable: false,           // (true | false) Determines if option groups can be collapsed.
-      groupColumns: false                 // (true | false)  Displays groups in a horizonal column layout.
+      groupColumns: false,                // (true | false)  Displays groups in a horizonal column layout.
+      groupColumnsWidth: false,           // (true | false)  Displays groups in a horizonal column layout.
     },
 
     /**
@@ -314,7 +315,7 @@
       // bump unique ID after assigning it to the widget instance
       this.multiselectID = multiselectID++;
 
-      
+
       this.$headerLinkContainer = $( document.createElement('ul') )
             .addClass('ui-helper-reset')
             .html( this._buildHeaderHtml()
@@ -480,7 +481,13 @@
 
       var item = document.createElement('li');
       item.className = (isDisabled ? 'ui-multiselect-disabled ' : '')
+                        + (this.options.groupColumns ? ' ui-multiselect-columns' : '')
                         + (option.className || '');
+
+      if (this.options.groupColumnsWidth) {
+        item.style = (item.style != '' ? ';':'') + 'width:'+this.options.groupColumnsWidth+'px';
+      }
+
       item.appendChild(label);
 
       return item;
@@ -525,6 +532,7 @@
                                  .addClass('ui-multiselect-optgroup'
                                     + (self.options.groupColumns ? ' ui-multiselect-columns' : '')
                                     + (elem.className ? ' ' + elem.className : ''))
+                                 .css(self.options.groupColumnsWidth ? 'width:'+self.options.groupColumnsWidth+'px':'')
                                  .append($collapseButton, $optGroupLabel, $optionGroup)
           list.push($optGroupItem);
         }
@@ -1357,7 +1365,7 @@
       if (this.$button) {
          this.$button.prop({ 'disabled':flag, 'aria-disabled':flag })[ flag ? 'addClass' : 'removeClass' ](disabledClass);
 	  }
-	  
+
       if (this.options.disableInputsOnToggle) {
          // Apply the ui-multiselect-disabled class name to identify which
          // input elements this widget disabled (not pre-disabled)

--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -198,7 +198,7 @@
       groupsSelectable: true,             // (true | false) Determines if clicking on an option group heading selects all of its options.
       groupsCollapsable: false,           // (true | false) Determines if option groups can be collapsed.
       groupColumns: false,                // (true | false)  Displays groups in a horizonal column layout.
-      groupColumnsWidth: false,           // (true | false)  Displays groups in a horizonal column layout.
+      groupColumnsWidth: false,           // (integer) The width of each select item in the groupColumns.
     },
 
     /**


### PR DESCRIPTION
### What changes are you proposing?  Why are they needed?
This is quite simple.  A function named in jquery-multiselect.filter.js is named incorrectly resulting in JavaScript errors when used in conjunction with jquery-multiselect.js.

### Related Issue numbers 
Closes #852

### Pull Request Approval Checklist:
  - [ x ] Tests Ran and 0 Failing
  - [ n/a ] Tests Added/Updated
  - [ n/a ] Impacted Demos Updated
  - [ n/a ] Impacted i18n Code Updated

