### PR TITLE
Option to add custom text for default linkInfo(header)

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -277,6 +277,19 @@
            }
          }
        }
+
+       if (this.options.header.constructor == Object) {
+       var options = Object.keys(this.options.header)
+       for (var x = 0; x < options.length; x++) {
+          var displayText = options[x];
+          var linkInfoKey = this.options.header[displayText];
+          if (linkInfoKey && linkInfoKey in this.linkInfo
+              && !(this.options.maxSelected && linkInfoKey === 'checkAll')
+              && ['open', 'close', 'collapse', 'expand'].indexOf(linkInfoKey) === -1) {
+              headerLinksHTML += this._linkHTML('<li><a class="{{class}}" title="{{title}}">{{icon}}<span>'+displayText+'</span></a></li>', linkInfoKey);
+          }
+        }
+      }
        return headerLinksHTML;
      },
 

--- a/tests/unit/options.js
+++ b/tests/unit/options.js
@@ -252,6 +252,13 @@
       assert.equal(menu().find(".ui-multiselect-all").text(), text, 'check all link reads ' + text);
 
       el.multiselect("destroy");
+
+      // set through dict
+      text = "foo";
+      el = $("select").multiselect({ header: {'foo':'checkAll'} });
+      assert.equal(menu().find(".ui-multiselect-all").text(), text, 'check all link reads through obj ' + text);
+
+      el.multiselect("destroy");
     });
 
     QUnit.test("uncheckAllText", function (assert) {
@@ -264,6 +271,13 @@
       text = "bar";
       el.multiselect("option", "uncheckAllText", "bar");
       assert.equal(menu().find(".ui-multiselect-none").text(), text, 'changing value through api to ' + text);
+
+      el.multiselect("destroy");
+
+      // set through dict
+      text = "foo";
+      el = $("select").multiselect({ header: {'foo':'uncheckAll'} });
+      assert.equal(menu().find(".ui-multiselect-none").text(), text, 'uncheck all link reads through obj ' + text);
 
       el.multiselect("destroy");
     });
@@ -280,6 +294,13 @@
       assert.equal(menu().find(".ui-multiselect-flip").text(), text, 'changing value through api to ' + text);
 
       el.multiselect("destroy");
+
+      // set through dict
+      text = "foo";
+      el = $("select").multiselect({ header: {'foo':'flipAll'} });
+      assert.equal(menu().find(".ui-multiselect-flip").text(), text, 'flip all link reads through obj ' + text);
+
+      el.multiselect("destroy");
     });
 
     QUnit.test("collapseAllText", function (assert) {
@@ -294,6 +315,13 @@
       assert.equal(menu().find(".ui-multiselect-collapseall").text(), text, 'changing value through api to ' + text);
 
       el.multiselect("destroy");
+
+      // set through dict
+      text = "foo";
+      el = $("select").multiselect({ header: {'foo':'collapseAll'} });
+      assert.equal(menu().find(".ui-multiselect-collapseall").text(), text, 'collapse all link reads through obj ' + text);
+
+      el.multiselect("destroy");
     });
 
     QUnit.test("expandAllText", function (assert) {
@@ -306,6 +334,13 @@
       text = "bar";
       el.multiselect("option", "expandAllText", "bar");
       assert.equal(menu().find(".ui-multiselect-expandall").text(), text, 'changing value through api to ' + text);
+
+      el.multiselect("destroy");
+
+      // set through dict
+      text = "foo";
+      el = $("select").multiselect({ header: {'foo':'expandAll'} });
+      assert.equal(menu().find(".ui-multiselect-expandall").text(), text, 'expand all link reads through obj ' + text);
 
       el.multiselect("destroy");
     });


### PR DESCRIPTION
### Why are they needed?
This allows users to send an object in the header option with a custom name for available linkInfo.