### PR TITLE
bugfix

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -248,7 +248,7 @@
          .html(this._linkHTML('<span class="{{class}}" title="{{title}}">{{icon}}</span>', 'open'));
 
        this.$buttonlabel = $(document.createElement('span'))
-         .html(this.options.noneSelectedText || $element[0].placeholder)
+         .html(this.options.noneSelectedText || this.element[0].placeholder)
          .appendTo($button);
        return $button;
      },


### PR DESCRIPTION
- fixing wrong $elemnent access

### What changes are you proposing?  Why are they needed?
if noneSelectedText set to '' it throw a js error: $element not exists...

