### PR TITLE
Removed focus event shorthand invocation.

### DIFF
--- a/src/jquery.multiselect.js
+++ b/src/jquery.multiselect.js
@@ -864,7 +864,7 @@
           var scrollY = window.pageYOffset;
 
           self.$labels.removeClass('ui-state-hover');
-          $(this).addClass('ui-state-hover').find('input').focus();
+          $(this).addClass('ui-state-hover').find('input').trigger('focus');
 
           // Restore scroll positions if altered by setting input focus
           if ( !param || !param.allowScroll ) {
@@ -890,7 +890,7 @@
           case 9: // tab
             if (e.shiftKey) {
               self.$menu.find('.ui-state-hover').removeClass('ui-state-hover');
-              self.$header.find('li').last().find('a').focus();
+              self.$header.find('li').last().find('a').trigger('focus');
             } else {
               self.close();
             }
@@ -1338,7 +1338,7 @@
       $inputs.each(self._toggleState('checked', flag));
 
       // Give the first input focus
-      $inputs.eq(0).focus();
+      $inputs.eq(0).trigger('focus');
 
       // update button text
       self.update();


### PR DESCRIPTION
### What changes are you proposing?  Why are they needed?
I'm trying to migrate to jQuery 3.6.0 and found out warnings as follows:
![image](https://user-images.githubusercontent.com/1393989/148872272-c8e9bba1-068d-4453-a2af-efda8a42d174.png)

We can simply replace `focus()` with `trigger('focus')` to eliminate these warnings.

### Related Issue numbers 
N/A

### Pull Request Approval Checklist:
Honestly, I don't know how to add tests, but the changes are quite straightforward and they work well in my project.
